### PR TITLE
Improve meal planner UX and dev workflow

### DIFF
--- a/components/meal-slot.tsx
+++ b/components/meal-slot.tsx
@@ -2,7 +2,8 @@
 
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
-import { X, Plus, Sparkles, AlertTriangle, Utensils, ExternalLink } from 'lucide-react'
+import { X, Plus, Sparkles, AlertTriangle, Utensils, ExternalLink, Pencil } from 'lucide-react'
+import Link from 'next/link'
 
 interface Recipe {
   id: string
@@ -58,9 +59,11 @@ interface MealSlotProps {
   onClear?: () => void
   onAddSide?: () => void
   onRemoveSide?: (recipeId: string) => void
+  onEdit?: () => void
+  mainRecipeId?: string
 }
 
-export function MealSlot({ label, meal, lunchboxItems = [], memberLunchMeals = [], memberDinnerMeals = [], onClick, onClear, onAddSide, onRemoveSide }: MealSlotProps) {
+export function MealSlot({ label, meal, lunchboxItems = [], memberLunchMeals = [], memberDinnerMeals = [], onClick, onClear, onAddSide, onRemoveSide, onEdit, mainRecipeId }: MealSlotProps) {
   const mainRecipe = meal?.recipes?.find((r) => r.role === 'MAIN')?.recipe
   const sideRecipes = meal?.recipes?.filter((r) => r.role === 'SIDE') || []
 
@@ -129,12 +132,38 @@ export function MealSlot({ label, meal, lunchboxItems = [], memberLunchMeals = [
         {/* Dinner: Recipe display */}
         {!isLunch && hasMainOrPlaceholder && (
           <div className="space-y-1.5">
-            <p className="text-sm font-medium leading-tight text-foreground flex items-center gap-1">
-              {mainRecipe?.title || meal?.placeholderTitle}
-              {mainRecipe?.sourceUrl && (
-                <ExternalLink className="h-3 w-3 text-muted-foreground shrink-0" />
+            <div className="flex items-center gap-1.5">
+              {mainRecipeId ? (
+                <Link
+                  href={`/recipes/${mainRecipeId}`}
+                  onClick={(e) => e.stopPropagation()}
+                  className="text-sm font-medium leading-tight text-foreground hover:text-primary hover:underline flex items-center gap-1 flex-1 min-w-0"
+                >
+                  <span className="truncate">{mainRecipe?.title}</span>
+                  {mainRecipe?.sourceUrl && (
+                    <ExternalLink className="h-3 w-3 text-muted-foreground shrink-0" />
+                  )}
+                </Link>
+              ) : (
+                <p className="text-sm font-medium leading-tight text-foreground flex items-center gap-1 flex-1 min-w-0">
+                  <span className="truncate">{meal?.placeholderTitle}</span>
+                </p>
               )}
-            </p>
+              {onEdit && (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="h-6 w-6 p-0 shrink-0 text-muted-foreground hover:text-primary hover:bg-primary/10"
+                  onClick={(e) => {
+                    e.stopPropagation()
+                    onEdit()
+                  }}
+                  aria-label="Edit meal"
+                >
+                  <Pencil className="h-3.5 w-3.5" />
+                </Button>
+              )}
+            </div>
 
             {/* Sides display */}
             {sideRecipes.length > 0 && (

--- a/components/week-view.tsx
+++ b/components/week-view.tsx
@@ -555,6 +555,8 @@ export function WeekView({ recipes, familyMembers }: WeekViewProps) {
                             ? (recipeId) => handleRemoveSide(dinnerMeal.id, recipeId)
                             : undefined
                         }
+                        mainRecipeId={dinnerMeal?.recipes?.find((r) => r.role === 'MAIN')?.recipe?.id}
+                        onEdit={() => handleSlotClick(index, 'DINNER')}
                       />
                       <MealSlot
                         label="Lunch"
@@ -567,6 +569,8 @@ export function WeekView({ recipes, familyMembers }: WeekViewProps) {
                           placeholderTitle: m.placeholderTitle,
                         }))}
                         onClick={() => handleSlotClick(index, 'LUNCH')}
+                        mainRecipeId={lunchMeal?.recipes?.find((r) => r.role === 'MAIN')?.recipe?.id}
+                        onEdit={() => handleSlotClick(index, 'LUNCH')}
                       />
                     </CardContent>
                   </Card>
@@ -654,6 +658,8 @@ export function WeekView({ recipes, familyMembers }: WeekViewProps) {
                             ? (recipeId) => handleRemoveSide(dinnerMeal.id, recipeId)
                             : undefined
                         }
+                        mainRecipeId={dinnerMeal?.recipes?.find((r) => r.role === 'MAIN')?.recipe?.id}
+                        onEdit={() => handleSlotClick(index, 'DINNER')}
                       />
                       <MealSlot
                         label="Lunch"
@@ -666,6 +672,8 @@ export function WeekView({ recipes, familyMembers }: WeekViewProps) {
                           placeholderTitle: m.placeholderTitle,
                         }))}
                         onClick={() => handleSlotClick(index, 'LUNCH')}
+                        mainRecipeId={lunchMeal?.recipes?.find((r) => r.role === 'MAIN')?.recipe?.id}
+                        onEdit={() => handleSlotClick(index, 'LUNCH')}
                       />
                     </CardContent>
                   </Card>

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -19,15 +19,17 @@ if ! docker info > /dev/null 2>&1; then
     exit 1
 fi
 
-# Start PostgreSQL
-echo "📦 Starting PostgreSQL database..."
-docker compose up -d
-
-# Wait for PostgreSQL to be ready
-echo "⏳ Waiting for PostgreSQL to be ready..."
-until docker compose exec -T postgres pg_isready -U familytable > /dev/null 2>&1; do
-    sleep 1
-done
+# Start PostgreSQL (or use existing container from another worktree)
+if docker ps --format '{{.Names}}' | grep -q '^familytable-db$'; then
+    echo "✅ PostgreSQL already running (reusing existing container)"
+else
+    echo "📦 Starting PostgreSQL database..."
+    docker compose up -d
+    echo "⏳ Waiting for PostgreSQL to be ready..."
+    until docker exec familytable-db pg_isready -U familytable > /dev/null 2>&1; do
+        sleep 1
+    done
+fi
 echo "✅ PostgreSQL is ready"
 
 # Run Prisma migrations


### PR DESCRIPTION
## Summary
- Recipe titles in meal slots now link directly to recipe detail pages
- Added edit button (pencil icon) for quick meal editing
- Dev script now reuses existing DB container across git worktrees, avoiding conflicts

## Test plan
- [ ] Click recipe title in meal slot → navigates to recipe page
- [ ] Click pencil icon → opens meal edit dialog
- [ ] Run `dev.sh` in two worktrees → second should detect existing container