### PR TITLE
Fix session not persisting when navigating to main page

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,4 +1,6 @@
+import { redirect } from 'next/navigation'
 import Link from 'next/link'
+import { auth } from '@/lib/auth'
 import { Button } from '@/components/ui/button'
 import {
   ChefHat,
@@ -17,7 +19,13 @@ import {
   CalendarDays,
 } from 'lucide-react'
 
-export default function HomePage() {
+export default async function HomePage() {
+  const session = await auth()
+
+  if (session?.user?.householdId) {
+    redirect('/planner')
+  }
+
   return (
     <div className="flex min-h-screen flex-col overflow-hidden">
       {/* Header */}

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -182,5 +182,6 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
   },
   session: {
     strategy: 'jwt',
+    maxAge: 30 * 24 * 60 * 60, // 30 days
   },
 })


### PR DESCRIPTION
## Summary
- Add 30-day `maxAge` to JWT session configuration to prevent sessions from expiring when the browser closes
- Redirect authenticated users from the landing page (`/`) to `/planner`

Fixes #8

## Test plan
- [ ] Sign in with credentials
- [ ] Navigate to `/` - should redirect to `/planner`
- [ ] Close and reopen browser
- [ ] Navigate to `/` - should still redirect (session persisted)
- [ ] Sign out
- [ ] Navigate to `/` - should show landing page