### PR TITLE
Add AI-powered meal planning feature

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,3 +37,7 @@ NEXT_PUBLIC_APP_URL="http://localhost:3000"
 # Get API key from: https://console.anthropic.com/settings/keys
 # Set a spending limit in the console to manage costs (~$0.001 per generation)
 ANTHROPIC_API_KEY=""
+
+# Brave Search API (for web recipe search)
+# Get API key from: https://brave.com/search/api/
+BRAVE_SEARCH_API_KEY=""

--- a/.env.example
+++ b/.env.example
@@ -37,10 +37,3 @@ NEXT_PUBLIC_APP_URL="http://localhost:3000"
 # Get API key from: https://console.anthropic.com/settings/keys
 # Set a spending limit in the console to manage costs (~$0.001 per generation)
 ANTHROPIC_API_KEY=""
-
-# Google Custom Search API (for web recipe discovery)
-# API key from: https://console.cloud.google.com/apis/credentials
-# Search Engine ID from: https://programmablesearchengine.google.com/
-# Free tier: 100 queries/day
-GOOGLE_SEARCH_API_KEY=""
-GOOGLE_SEARCH_ENGINE_ID=""

--- a/.env.example
+++ b/.env.example
@@ -32,3 +32,15 @@ NEXT_PUBLIC_APP_URL="http://localhost:3000"
 # Set this to your production URL when testing emails locally,
 # since Gmail/Outlook can't fetch images from localhost
 # EMAIL_ASSETS_URL="https://yourdomain.com"
+
+# Anthropic API (for AI meal planning)
+# Get API key from: https://console.anthropic.com/settings/keys
+# Set a spending limit in the console to manage costs (~$0.001 per generation)
+ANTHROPIC_API_KEY=""
+
+# Google Custom Search API (for web recipe discovery)
+# API key from: https://console.cloud.google.com/apis/credentials
+# Search Engine ID from: https://programmablesearchengine.google.com/
+# Free tier: 100 queries/day
+GOOGLE_SEARCH_API_KEY=""
+GOOGLE_SEARCH_ENGINE_ID=""

--- a/app/api/ai-planner/context/route.ts
+++ b/app/api/ai-planner/context/route.ts
@@ -1,0 +1,340 @@
+import { NextResponse } from 'next/server'
+import { db } from '@/lib/db'
+import { getAuth } from '@/lib/api-auth'
+import { Rating, FamilyRole } from '@prisma/client'
+import type { PlannerContext, WebRecipeContext } from '@/lib/ai-planner/types'
+import { searchWebRecipes, buildSearchQueries } from '@/lib/ai-planner/web-search'
+
+const MAX_RECIPES = 30
+const MIN_RECIPES_FOR_VARIETY = 10 // If fewer recipes, search the web
+const MAX_RECENT_MEALS = 20
+const WEEKS_TO_LOOK_BACK = 4
+const PERISHABLE_DAYS_THRESHOLD = 7
+
+export async function GET(request: Request) {
+  try {
+    const authResult = await getAuth(request)
+    if (!authResult) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    const { searchParams } = new URL(request.url)
+    const weekStartParam = searchParams.get('weekStart')
+
+    if (!weekStartParam) {
+      return NextResponse.json(
+        { error: 'weekStart query parameter is required' },
+        { status: 400 }
+      )
+    }
+
+    const weekStart = new Date(weekStartParam)
+    if (isNaN(weekStart.getTime())) {
+      return NextResponse.json(
+        { error: 'Invalid weekStart date format' },
+        { status: 400 }
+      )
+    }
+
+    const householdId = authResult.householdId
+    const today = new Date()
+
+    // Fetch family members
+    const familyMembers = await db.familyMember.findMany({
+      where: { householdId },
+      select: { name: true, role: true },
+      orderBy: [{ role: 'asc' }, { name: 'asc' }],
+    })
+
+    // Fetch all recipes with ratings
+    const recipes = await db.recipe.findMany({
+      where: { householdId },
+      include: {
+        ratings: {
+          include: {
+            member: { select: { role: true } },
+          },
+        },
+      },
+    })
+
+    // Fetch recent meal plans for last-used dates
+    const weeksAgo = new Date()
+    weeksAgo.setDate(weeksAgo.getDate() - WEEKS_TO_LOOK_BACK * 7)
+
+    const recentMealPlans = await db.mealPlan.findMany({
+      where: {
+        householdId,
+        weekStartDate: { gte: weeksAgo },
+      },
+      include: {
+        plannedMeals: {
+          where: { mealType: 'DINNER', familyMemberId: null },
+          include: {
+            recipes: {
+              where: { role: 'MAIN' },
+              select: { recipeId: true, recipe: { select: { title: true } } },
+            },
+          },
+        },
+      },
+      orderBy: { weekStartDate: 'desc' },
+    })
+
+    // Build map of recipeId -> most recent usage date
+    const lastUsedMap = new Map<string, Date>()
+    const recentMealsData: Array<{ title: string; weeksAgo: number; weekStartDate: Date }> = []
+
+    for (const plan of recentMealPlans) {
+      const weeksAgoValue = Math.floor(
+        (today.getTime() - plan.weekStartDate.getTime()) / (1000 * 60 * 60 * 24 * 7)
+      )
+
+      for (const meal of plan.plannedMeals) {
+        for (const pmr of meal.recipes) {
+          // Track last used for scoring
+          const existing = lastUsedMap.get(pmr.recipeId)
+          if (!existing || plan.weekStartDate > existing) {
+            lastUsedMap.set(pmr.recipeId, plan.weekStartDate)
+          }
+
+          // Track for recent meals list
+          if (pmr.recipe?.title) {
+            recentMealsData.push({
+              title: pmr.recipe.title,
+              weeksAgo: weeksAgoValue,
+              weekStartDate: plan.weekStartDate,
+            })
+          }
+        }
+      }
+    }
+
+    // Score and categorize recipes
+    type ScoredRecipe = {
+      id: string
+      title: string
+      tags: string[]
+      score: number
+      daysSinceUsed: number | null
+      kidDownVotes: number
+    }
+
+    const favoriteRecipes: ScoredRecipe[] = []
+    const avoidRecipes: Array<{ id: string; title: string; kidDownVotes: number }> = []
+    const tagScores = new Map<string, number>()
+
+    for (const recipe of recipes) {
+      const upVotes = recipe.ratings.filter((r) => r.rating === Rating.UP).length
+      const downVotes = recipe.ratings.filter((r) => r.rating === Rating.DOWN).length
+      const kidDownVotes = recipe.ratings.filter(
+        (r) => r.rating === Rating.DOWN && r.member.role === FamilyRole.CHILD
+      ).length
+
+      // Calculate days since last used
+      const lastUsed = lastUsedMap.get(recipe.id)
+      const daysSinceUsed = lastUsed
+        ? Math.floor((today.getTime() - lastUsed.getTime()) / (1000 * 60 * 60 * 24))
+        : null
+
+      // Recipes with kid downvotes should be avoided
+      if (kidDownVotes > 0) {
+        avoidRecipes.push({
+          id: recipe.id,
+          title: recipe.title,
+          kidDownVotes,
+        })
+        continue // Don't include in favorites
+      }
+
+      // Calculate score: upvotes + recency bonus
+      let score = upVotes * 20
+
+      // Add recency bonus: newer = less bonus (prefer variety)
+      if (daysSinceUsed !== null) {
+        if (daysSinceUsed > 21) score += 30 // Haven't made in 3+ weeks
+        else if (daysSinceUsed > 14) score += 15 // 2-3 weeks ago
+        else if (daysSinceUsed > 7) score += 5 // 1-2 weeks ago
+        // Recently made (< 1 week) gets no bonus
+      } else {
+        // Never made - slight bonus to encourage trying
+        score += 10
+      }
+
+      // Tag scoring for preferences
+      for (const tag of recipe.tags) {
+        tagScores.set(tag, (tagScores.get(tag) || 0) + upVotes - downVotes)
+      }
+
+      favoriteRecipes.push({
+        id: recipe.id,
+        title: recipe.title,
+        tags: recipe.tags,
+        score,
+        daysSinceUsed,
+        kidDownVotes: 0,
+      })
+    }
+
+    // Sort favorites by score and limit
+    favoriteRecipes.sort((a, b) => b.score - a.score)
+    const topFavorites = favoriteRecipes.slice(0, MAX_RECIPES).map((r) => ({
+      id: r.id,
+      title: r.title,
+      tags: r.tags,
+      score: r.score,
+      daysSinceUsed: r.daysSinceUsed,
+    }))
+
+    // Sort avoid recipes by kid downvotes
+    avoidRecipes.sort((a, b) => b.kidDownVotes - a.kidDownVotes)
+
+    // Get preferred tags
+    const preferredTags = Array.from(tagScores.entries())
+      .filter(([, score]) => score > 0)
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, 10)
+      .map(([tag]) => tag)
+
+    // Deduplicate recent meals and limit
+    const seenTitles = new Set<string>()
+    const recentMeals = recentMealsData
+      .filter((m) => {
+        if (seenTitles.has(m.title)) return false
+        seenTitles.add(m.title)
+        return true
+      })
+      .sort((a, b) => a.weeksAgo - b.weeksAgo)
+      .slice(0, MAX_RECENT_MEALS)
+      .map((m) => ({ title: m.title, weeksAgo: m.weeksAgo }))
+
+    // Fetch perishables expiring soon
+    const perishableDeadline = new Date()
+    perishableDeadline.setDate(perishableDeadline.getDate() + PERISHABLE_DAYS_THRESHOLD)
+
+    const perishables = await db.perishable.findMany({
+      where: {
+        householdId,
+        expirationDate: {
+          gte: today,
+          lte: perishableDeadline,
+        },
+      },
+      select: { displayName: true, expirationDate: true },
+      orderBy: { expirationDate: 'asc' },
+    })
+
+    const perishablesContext = perishables.map((p) => ({
+      name: p.displayName,
+      daysUntilExpiration: p.expirationDate
+        ? Math.ceil((p.expirationDate.getTime() - today.getTime()) / (1000 * 60 * 60 * 24))
+        : 7,
+    }))
+
+    // Fetch existing meals for this week
+    const existingMealPlan = await db.mealPlan.findUnique({
+      where: {
+        householdId_weekStartDate: {
+          householdId,
+          weekStartDate: weekStart,
+        },
+      },
+      include: {
+        plannedMeals: {
+          where: { mealType: 'DINNER', familyMemberId: null },
+          include: {
+            recipes: {
+              where: { role: 'MAIN' },
+              select: { recipe: { select: { title: true } } },
+            },
+          },
+        },
+      },
+    })
+
+    const existingMeals = (existingMealPlan?.plannedMeals || []).map((meal) => ({
+      dayOfWeek: meal.dayOfWeek,
+      title:
+        meal.recipes[0]?.recipe?.title ||
+        meal.placeholderTitle ||
+        'Planned meal',
+    }))
+
+    // Check if we should search the web for more recipes
+    const includeWebSearch = searchParams.get('includeWebSearch') === 'true'
+    const userPrompt = searchParams.get('userPrompt') || undefined
+    let webRecipes: WebRecipeContext[] | undefined
+    let webSearchStatus: string | undefined
+
+    // Search web if enabled AND (user requested OR local recipes are sparse)
+    const shouldSearchWeb = includeWebSearch && (userPrompt || topFavorites.length < MIN_RECIPES_FOR_VARIETY)
+
+    if (shouldSearchWeb) {
+      // Check if API is configured
+      if (!process.env.GOOGLE_SEARCH_API_KEY || !process.env.GOOGLE_SEARCH_ENGINE_ID) {
+        console.log('Web search requested but Google API not configured')
+        webSearchStatus = 'not_configured'
+      } else {
+        const perishableNames = perishablesContext.map((p) => p.name)
+        const searchQueries = buildSearchQueries(perishableNames, preferredTags, userPrompt)
+
+        console.log('Web search queries:', searchQueries)
+
+        // Run searches in parallel (limit to save API quota)
+        const searchPromises = searchQueries.slice(0, 2).map((q) => searchWebRecipes(q, 5))
+        const searchResults = await Promise.all(searchPromises)
+
+        // Deduplicate by URL and collect results
+        const seenUrls = new Set<string>()
+        webRecipes = []
+
+        for (const result of searchResults) {
+          for (const recipe of result.results) {
+            if (!seenUrls.has(recipe.url)) {
+              seenUrls.add(recipe.url)
+              webRecipes.push({
+                url: recipe.url,
+                title: recipe.title,
+                snippet: recipe.snippet,
+                source: recipe.source,
+              })
+            }
+          }
+        }
+
+        // Limit total web recipes
+        webRecipes = webRecipes.slice(0, 10)
+        console.log(`Web search found ${webRecipes.length} recipes`)
+
+        if (webRecipes.length > 0) {
+          webSearchStatus = 'success'
+        } else {
+          webSearchStatus = 'no_results'
+        }
+      }
+    }
+
+    const response: PlannerContext = {
+      family: {
+        members: familyMembers,
+      },
+      preferences: {
+        favoriteRecipes: topFavorites,
+        avoidRecipes,
+        preferredTags,
+      },
+      recentMeals,
+      perishables: perishablesContext,
+      existingMeals,
+      webRecipes,
+    }
+
+    return NextResponse.json(response)
+  } catch (error) {
+    console.error('Error fetching AI planner context:', error)
+    return NextResponse.json(
+      { error: 'Failed to fetch AI planner context' },
+      { status: 500 }
+    )
+  }
+}

--- a/app/api/ai-planner/context/route.ts
+++ b/app/api/ai-planner/context/route.ts
@@ -270,47 +270,41 @@ export async function GET(request: Request) {
     const shouldSearchWeb = includeWebSearch && (userPrompt || topFavorites.length < MIN_RECIPES_FOR_VARIETY)
 
     if (shouldSearchWeb) {
-      // Check if API is configured
-      if (!process.env.GOOGLE_SEARCH_API_KEY || !process.env.GOOGLE_SEARCH_ENGINE_ID) {
-        console.log('Web search requested but Google API not configured')
-        webSearchStatus = 'not_configured'
-      } else {
-        const perishableNames = perishablesContext.map((p) => p.name)
-        const searchQueries = buildSearchQueries(perishableNames, preferredTags, userPrompt)
+      const perishableNames = perishablesContext.map((p) => p.name)
+      const searchQueries = buildSearchQueries(perishableNames, preferredTags, userPrompt)
 
-        console.log('Web search queries:', searchQueries)
+      console.log('Web search queries:', searchQueries)
 
-        // Run searches in parallel (limit to save API quota)
-        const searchPromises = searchQueries.slice(0, 2).map((q) => searchWebRecipes(q, 5))
-        const searchResults = await Promise.all(searchPromises)
+      // Run searches in parallel
+      const searchPromises = searchQueries.slice(0, 2).map((q) => searchWebRecipes(q, 5))
+      const searchResults = await Promise.all(searchPromises)
 
-        // Deduplicate by URL and collect results
-        const seenUrls = new Set<string>()
-        webRecipes = []
+      // Deduplicate by URL and collect results
+      const seenUrls = new Set<string>()
+      webRecipes = []
 
-        for (const result of searchResults) {
-          for (const recipe of result.results) {
-            if (!seenUrls.has(recipe.url)) {
-              seenUrls.add(recipe.url)
-              webRecipes.push({
-                url: recipe.url,
-                title: recipe.title,
-                snippet: recipe.snippet,
-                source: recipe.source,
-              })
-            }
+      for (const result of searchResults) {
+        for (const recipe of result.results) {
+          if (!seenUrls.has(recipe.url)) {
+            seenUrls.add(recipe.url)
+            webRecipes.push({
+              url: recipe.url,
+              title: recipe.title,
+              snippet: recipe.snippet,
+              source: recipe.source,
+            })
           }
         }
+      }
 
-        // Limit total web recipes
-        webRecipes = webRecipes.slice(0, 10)
-        console.log(`Web search found ${webRecipes.length} recipes`)
+      // Limit total web recipes
+      webRecipes = webRecipes.slice(0, 10)
+      console.log(`Web search found ${webRecipes.length} recipes`)
 
-        if (webRecipes.length > 0) {
-          webSearchStatus = 'success'
-        } else {
-          webSearchStatus = 'no_results'
-        }
+      if (webRecipes.length > 0) {
+        webSearchStatus = 'success'
+      } else {
+        webSearchStatus = 'no_results'
       }
     }
 

--- a/app/api/ai-planner/context/route.ts
+++ b/app/api/ai-planner/context/route.ts
@@ -3,7 +3,7 @@ import { db } from '@/lib/db'
 import { getAuth } from '@/lib/api-auth'
 import { Rating, FamilyRole } from '@prisma/client'
 import type { PlannerContext, WebRecipeContext } from '@/lib/ai-planner/types'
-import { searchWebRecipes, buildSearchQueries } from '@/lib/ai-planner/web-search'
+import { searchWebRecipes, buildSearchQueries, enrichWithImages, type SearchQueryContext } from '@/lib/ai-planner/web-search'
 
 const MAX_RECIPES = 30
 const MIN_RECIPES_FOR_VARIETY = 10 // If fewer recipes, search the web
@@ -118,6 +118,7 @@ export async function GET(request: Request) {
       score: number
       daysSinceUsed: number | null
       kidDownVotes: number
+      imageUrl: string | null
     }
 
     const favoriteRecipes: ScoredRecipe[] = []
@@ -173,6 +174,7 @@ export async function GET(request: Request) {
         score,
         daysSinceUsed,
         kidDownVotes: 0,
+        imageUrl: recipe.imageUrl,
       })
     }
 
@@ -184,6 +186,7 @@ export async function GET(request: Request) {
       tags: r.tags,
       score: r.score,
       daysSinceUsed: r.daysSinceUsed,
+      imageUrl: r.imageUrl,
     }))
 
     // Sort avoid recipes by kid downvotes
@@ -270,36 +273,36 @@ export async function GET(request: Request) {
     const shouldSearchWeb = includeWebSearch && (userPrompt || topFavorites.length < MIN_RECIPES_FOR_VARIETY)
 
     if (shouldSearchWeb) {
-      const perishableNames = perishablesContext.map((p) => p.name)
-      const searchQueries = buildSearchQueries(perishableNames, preferredTags, userPrompt)
-
-      console.log('Web search queries:', searchQueries)
-
-      // Run searches in parallel
-      const searchPromises = searchQueries.slice(0, 2).map((q) => searchWebRecipes(q, 5))
-      const searchResults = await Promise.all(searchPromises)
-
-      // Deduplicate by URL and collect results
-      const seenUrls = new Set<string>()
-      webRecipes = []
-
-      for (const result of searchResults) {
-        for (const recipe of result.results) {
-          if (!seenUrls.has(recipe.url)) {
-            seenUrls.add(recipe.url)
-            webRecipes.push({
-              url: recipe.url,
-              title: recipe.title,
-              snippet: recipe.snippet,
-              source: recipe.source,
-            })
-          }
-        }
+      // Build rich context for LLM query generation
+      const queryContext: SearchQueryContext = {
+        userPrompt,
+        perishables: perishablesContext.map((p) => p.name),
+        preferredTags,
+        recentMeals: recentMeals.map((m) => m.title),
+        familyNotes: familyMembers.length > 0
+          ? `${familyMembers.filter(m => m.role === 'ADULT').length} adults, ${familyMembers.filter(m => m.role === 'CHILD').length} children`
+          : undefined,
       }
 
-      // Limit total web recipes
-      webRecipes = webRecipes.slice(0, 10)
-      console.log(`Web search found ${webRecipes.length} recipes`)
+      const searchQueries = await buildSearchQueries(queryContext)
+
+      console.log('Web search query:', searchQueries[0])
+
+      // Single search with more results (avoid rate limits)
+      const searchResult = await searchWebRecipes(searchQueries[0], 10)
+
+      const dedupedResults = searchResult.results
+      const enrichedResults = await enrichWithImages(dedupedResults)
+
+      webRecipes = enrichedResults.map((r) => ({
+        url: r.url,
+        title: r.title,
+        snippet: r.snippet,
+        source: r.source,
+        imageUrl: r.imageUrl,
+      }))
+
+      console.log(`Web search found ${webRecipes.length} recipes with ${webRecipes.filter(r => r.imageUrl).length} images`)
 
       if (webRecipes.length > 0) {
         webSearchStatus = 'success'

--- a/app/api/ai-planner/generate/route.ts
+++ b/app/api/ai-planner/generate/route.ts
@@ -120,6 +120,20 @@ export async function POST(request: Request) {
           return true
         })
 
+        // Enrich suggestions with image URLs
+        const recipeImageMap = new Map(
+          availableRecipes.map((r) => [r.id, r.imageUrl])
+        )
+        const webRecipeImageMap = new Map(
+          webRecipes.map((r) => [r.url, r.imageUrl])
+        )
+        suggestions = suggestions.map((s) => ({
+          ...s,
+          imageUrl: s.isWebRecipe
+            ? webRecipeImageMap.get(s.recipeId) || null
+            : recipeImageMap.get(s.recipeId) || null,
+        }))
+
         // If we got at least some valid suggestions, we're good
         if (suggestions.length > 0) {
           break

--- a/app/api/ai-planner/generate/route.ts
+++ b/app/api/ai-planner/generate/route.ts
@@ -1,0 +1,174 @@
+import { NextResponse } from 'next/server'
+import Anthropic from '@anthropic-ai/sdk'
+import { getAuth } from '@/lib/api-auth'
+import { SYSTEM_PROMPT, buildUserPrompt, parseAIResponse } from '@/lib/ai-planner/prompt'
+import type { GenerateRequest, GenerateResponse, AISuggestion } from '@/lib/ai-planner/types'
+
+const MAX_RETRIES = 1
+const MODEL = 'claude-haiku-4-5-20251001'
+
+export async function POST(request: Request) {
+  try {
+    const authResult = await getAuth(request)
+    if (!authResult) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    // Validate API key is configured
+    if (!process.env.ANTHROPIC_API_KEY) {
+      return NextResponse.json(
+        { error: 'AI features not configured. Please set ANTHROPIC_API_KEY.' },
+        { status: 503 }
+      )
+    }
+
+    const body: GenerateRequest = await request.json()
+
+    // Validate request
+    if (!body.context) {
+      return NextResponse.json(
+        { error: 'Missing context in request body' },
+        { status: 400 }
+      )
+    }
+
+    if (!body.daysToGenerate || body.daysToGenerate.length === 0) {
+      return NextResponse.json(
+        { error: 'No days specified to generate suggestions for' },
+        { status: 400 }
+      )
+    }
+
+    // Check if there are any recipes to suggest (local or web)
+    const availableRecipes = body.context.preferences.favoriteRecipes.filter(
+      (r) => !body.excludeRecipeIds?.includes(r.id)
+    )
+    const webRecipes = body.context.webRecipes || []
+
+    if (availableRecipes.length === 0 && webRecipes.length === 0) {
+      return NextResponse.json(
+        {
+          error: 'No recipes available to suggest',
+          code: 'NO_RECIPES',
+          details: 'Add some recipes to your collection first, or enable web search.',
+        },
+        { status: 400 }
+      )
+    }
+
+    const anthropic = new Anthropic()
+
+    const userPrompt = buildUserPrompt(
+      body.context,
+      body.daysToGenerate,
+      body.userPrompt,
+      body.excludeRecipeIds
+    )
+
+    let suggestions: AISuggestion[] = []
+    let inputTokens = 0
+    let outputTokens = 0
+    let lastError: Error | null = null
+
+    // Try to get valid suggestions, with retry on parse failure
+    for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+      try {
+        const response = await anthropic.messages.create({
+          model: MODEL,
+          max_tokens: 1024,
+          messages: [
+            {
+              role: 'user',
+              content: userPrompt,
+            },
+          ],
+          system: SYSTEM_PROMPT,
+        })
+
+        // Track token usage
+        inputTokens = response.usage.input_tokens
+        outputTokens = response.usage.output_tokens
+
+        // Extract text content
+        const textContent = response.content.find((c) => c.type === 'text')
+        if (!textContent || textContent.type !== 'text') {
+          throw new Error('No text response from AI')
+        }
+
+        // Parse the response
+        suggestions = parseAIResponse(textContent.text)
+
+        // Validate that suggested recipe IDs exist in available recipes or web recipes
+        const validRecipeIds = new Set(availableRecipes.map((r) => r.id))
+        const validWebUrls = new Set(webRecipes.map((r) => r.url))
+
+        suggestions = suggestions.filter((s) => {
+          // Web recipes use URL as recipeId
+          if (s.isWebRecipe) {
+            if (!validWebUrls.has(s.recipeId)) {
+              console.warn(`AI suggested invalid web recipe URL: ${s.recipeId}`)
+              return false
+            }
+            return true
+          }
+
+          // Regular recipes
+          if (!validRecipeIds.has(s.recipeId)) {
+            console.warn(`AI suggested invalid recipe ID: ${s.recipeId}`)
+            return false
+          }
+          return true
+        })
+
+        // If we got at least some valid suggestions, we're good
+        if (suggestions.length > 0) {
+          break
+        }
+
+        lastError = new Error('AI returned no valid recipe suggestions')
+      } catch (error) {
+        lastError = error instanceof Error ? error : new Error(String(error))
+        console.error(`AI generation attempt ${attempt + 1} failed:`, lastError)
+
+        // On last attempt, throw
+        if (attempt === MAX_RETRIES) {
+          throw lastError
+        }
+      }
+    }
+
+    // Return whatever suggestions we have
+    const response: GenerateResponse = {
+      suggestions,
+      usage: {
+        inputTokens,
+        outputTokens,
+      },
+    }
+
+    return NextResponse.json(response)
+  } catch (error) {
+    console.error('Error generating AI suggestions:', error)
+
+    // Handle specific Anthropic errors
+    if (error instanceof Anthropic.APIError) {
+      if (error.status === 401) {
+        return NextResponse.json(
+          { error: 'Invalid API key configuration' },
+          { status: 503 }
+        )
+      }
+      if (error.status === 429) {
+        return NextResponse.json(
+          { error: 'AI service rate limit exceeded. Please try again in a moment.' },
+          { status: 429 }
+        )
+      }
+    }
+
+    return NextResponse.json(
+      { error: 'Failed to generate meal suggestions' },
+      { status: 500 }
+    )
+  }
+}

--- a/components/ai-planner/ai-plan-button.tsx
+++ b/components/ai-planner/ai-plan-button.tsx
@@ -1,0 +1,115 @@
+'use client'
+
+import { useState } from 'react'
+import { Button } from '@/components/ui/button'
+import { Textarea } from '@/components/ui/textarea'
+import { AIPlanModal } from './ai-plan-modal'
+import { Sparkles, ChevronDown, Loader2 } from 'lucide-react'
+import type { AIPlanButtonProps } from '@/lib/ai-planner/types'
+
+export function AIPlanButton({
+  weekStart,
+  mealPlanId,
+  existingMeals,
+  onSuggestionsAccepted,
+}: AIPlanButtonProps) {
+  const [showPreferences, setShowPreferences] = useState(false)
+  const [userPrompt, setUserPrompt] = useState('')
+  const [modalOpen, setModalOpen] = useState(false)
+  const [isCreatingPlan, setIsCreatingPlan] = useState(false)
+  const [activeMealPlanId, setActiveMealPlanId] = useState<string | null>(mealPlanId)
+
+  // Count empty dinner slots
+  const plannedDays = new Set(existingMeals.map((m) => m.dayOfWeek))
+  const emptySlots = 7 - plannedDays.size
+
+  // Don't show if all days are planned
+  if (emptySlots === 0) {
+    return null
+  }
+
+  const handleOpenModal = async () => {
+    // If no meal plan exists, create one first
+    if (!activeMealPlanId) {
+      setIsCreatingPlan(true)
+      try {
+        const response = await fetch('/api/meal-plans', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ weekStartDate: weekStart.toISOString() }),
+        })
+
+        if (!response.ok) {
+          throw new Error('Failed to create meal plan')
+        }
+
+        const data = await response.json()
+        setActiveMealPlanId(data.id)
+        setModalOpen(true)
+      } catch (error) {
+        console.error('Failed to create meal plan:', error)
+      } finally {
+        setIsCreatingPlan(false)
+      }
+    } else {
+      setModalOpen(true)
+    }
+  }
+
+  const handleComplete = () => {
+    setUserPrompt('')
+    setShowPreferences(false)
+    onSuggestionsAccepted()
+  }
+
+  return (
+    <div className="flex flex-col items-center gap-2">
+      <Button
+        onClick={handleOpenModal}
+        disabled={isCreatingPlan}
+        className="gap-2"
+        size="lg"
+      >
+        {isCreatingPlan ? (
+          <Loader2 className="h-4 w-4 animate-spin" />
+        ) : (
+          <Sparkles className="h-4 w-4" />
+        )}
+        Plan This Week
+      </Button>
+
+      <Button
+        variant="ghost"
+        size="sm"
+        className="gap-1 text-muted-foreground"
+        onClick={() => setShowPreferences(!showPreferences)}
+      >
+        <ChevronDown
+          className={`h-3.5 w-3.5 transition-transform ${showPreferences ? 'rotate-180' : ''}`}
+        />
+        Add preferences
+      </Button>
+
+      {showPreferences && (
+        <Textarea
+          placeholder="e.g., guests Saturday, easy Wednesday, use up chicken..."
+          value={userPrompt}
+          onChange={(e) => setUserPrompt(e.target.value)}
+          className="min-h-[80px] w-[280px] text-sm resize-none"
+        />
+      )}
+
+      {activeMealPlanId && (
+        <AIPlanModal
+          open={modalOpen}
+          onOpenChange={setModalOpen}
+          weekStart={weekStart}
+          mealPlanId={activeMealPlanId}
+          userPrompt={userPrompt}
+          existingMeals={existingMeals}
+          onComplete={handleComplete}
+        />
+      )}
+    </div>
+  )
+}

--- a/components/ai-planner/ai-plan-modal.tsx
+++ b/components/ai-planner/ai-plan-modal.tsx
@@ -272,8 +272,8 @@ export function AIPlanModal({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-lg max-h-[85vh] flex flex-col">
-        <DialogHeader className="flex flex-row items-center justify-between shrink-0">
+      <DialogContent className="max-w-lg md:max-w-xl lg:max-w-2xl max-h-[85vh] flex flex-col">
+        <DialogHeader className="flex flex-row items-center justify-between shrink-0 pr-8">
           <DialogTitle className="flex items-center gap-2">
             <Sparkles className="h-5 w-5 text-primary" />
             Suggested Meals
@@ -283,7 +283,7 @@ export function AIPlanModal({
               variant="ghost"
               size="sm"
               onClick={handleRedoAll}
-              className="gap-1.5 -mr-2"
+              className="gap-1.5"
             >
               <RefreshCw className="h-4 w-4" />
               Redo

--- a/components/ai-planner/ai-plan-modal.tsx
+++ b/components/ai-planner/ai-plan-modal.tsx
@@ -1,0 +1,388 @@
+'use client'
+
+import { useState, useEffect, useCallback } from 'react'
+import { Button } from '@/components/ui/button'
+import { Textarea } from '@/components/ui/textarea'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { AISuggestionCard } from './ai-suggestion-card'
+import { Loader2, RefreshCw, Save, Sparkles, AlertCircle } from 'lucide-react'
+import { toast } from 'sonner'
+import type {
+  AIPlanModalProps,
+  PlannerContext,
+  AISuggestion,
+  DecisionStatus,
+  GenerateResponse,
+} from '@/lib/ai-planner/types'
+
+const DAYS_OF_WEEK = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday']
+
+export function AIPlanModal({
+  open,
+  onOpenChange,
+  weekStart,
+  mealPlanId,
+  userPrompt: initialUserPrompt,
+  existingMeals,
+  onComplete,
+}: AIPlanModalProps) {
+  const [status, setStatus] = useState<'idle' | 'loading' | 'ready' | 'saving' | 'error'>('idle')
+  const [suggestions, setSuggestions] = useState<AISuggestion[]>([])
+  const [decisions, setDecisions] = useState<Map<number, DecisionStatus>>(new Map())
+  const [rejectedRecipeIds, setRejectedRecipeIds] = useState<string[]>([])
+  const [feedbackText, setFeedbackText] = useState('')
+  const [error, setError] = useState<string | null>(null)
+  const [regeneratingDay, setRegeneratingDay] = useState<number | null>(null)
+  const [context, setContext] = useState<PlannerContext | null>(null)
+
+  // Calculate which days need suggestions
+  const existingDays = new Set(existingMeals.map((m) => m.dayOfWeek))
+  const daysToGenerate = [0, 1, 2, 3, 4, 5, 6].filter((d) => !existingDays.has(d))
+
+  // Reset state when modal opens
+  useEffect(() => {
+    if (open) {
+      setStatus('idle')
+      setSuggestions([])
+      setDecisions(new Map())
+      setRejectedRecipeIds([])
+      setFeedbackText('')
+      setError(null)
+      setRegeneratingDay(null)
+      setContext(null)
+    }
+  }, [open])
+
+  // Auto-generate when modal opens
+  useEffect(() => {
+    if (open && status === 'idle' && daysToGenerate.length > 0) {
+      generateSuggestions()
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, status])
+
+  const fetchContext = useCallback(async (userPromptForSearch?: string): Promise<PlannerContext | null> => {
+    const params = new URLSearchParams({
+      weekStart: weekStart.toISOString(),
+      includeWebSearch: 'true',
+    })
+    if (userPromptForSearch) {
+      params.set('userPrompt', userPromptForSearch)
+    }
+    const response = await fetch(`/api/ai-planner/context?${params}`)
+    if (!response.ok) {
+      const err = await response.json()
+      throw new Error(err.error || 'Failed to fetch context')
+    }
+    return response.json()
+  }, [weekStart])
+
+  const generateSuggestions = useCallback(
+    async (forDays?: number[], additionalExcludes?: string[]) => {
+      try {
+        setStatus('loading')
+        setError(null)
+
+        // Fetch fresh context if we don't have it
+        let ctx = context
+        if (!ctx) {
+          ctx = await fetchContext(feedbackText || initialUserPrompt)
+          setContext(ctx)
+        }
+
+        if (!ctx) {
+          throw new Error('Failed to load planning context')
+        }
+
+        const targetDays = forDays || daysToGenerate
+        const excludes = [...rejectedRecipeIds, ...(additionalExcludes || [])]
+
+        const response = await fetch('/api/ai-planner/generate', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            context: ctx,
+            userPrompt: feedbackText || initialUserPrompt,
+            daysToGenerate: targetDays,
+            excludeRecipeIds: excludes.length > 0 ? excludes : undefined,
+          }),
+        })
+
+        if (!response.ok) {
+          const err = await response.json()
+          throw new Error(err.error || 'Failed to generate suggestions')
+        }
+
+        const data: GenerateResponse = await response.json()
+
+        if (data.suggestions.length === 0) {
+          throw new Error('No suggestions could be generated. Try adding more recipes.')
+        }
+
+        // If regenerating specific days, merge with existing
+        if (forDays && forDays.length > 0) {
+          setSuggestions((prev) => {
+            const newSuggestions = [...prev]
+            for (const s of data.suggestions) {
+              const idx = newSuggestions.findIndex((x) => x.dayOfWeek === s.dayOfWeek)
+              if (idx >= 0) {
+                newSuggestions[idx] = s
+              } else {
+                newSuggestions.push(s)
+              }
+            }
+            return newSuggestions.sort((a, b) => a.dayOfWeek - b.dayOfWeek)
+          })
+
+          // Reset decision for regenerated days
+          setDecisions((prev) => {
+            const newDecisions = new Map(prev)
+            for (const day of forDays) {
+              newDecisions.set(day, 'pending')
+            }
+            return newDecisions
+          })
+        } else {
+          // Full regeneration
+          setSuggestions(data.suggestions.sort((a, b) => a.dayOfWeek - b.dayOfWeek))
+          setDecisions(new Map())
+        }
+
+        setStatus('ready')
+      } catch (err) {
+        console.error('Generation error:', err)
+        setError(err instanceof Error ? err.message : 'An error occurred')
+        setStatus('error')
+      }
+    },
+    [context, daysToGenerate, fetchContext, feedbackText, initialUserPrompt, rejectedRecipeIds]
+  )
+
+  const handleAccept = (dayOfWeek: number) => {
+    setDecisions((prev) => new Map(prev).set(dayOfWeek, 'accept'))
+  }
+
+  const handleReject = (dayOfWeek: number) => {
+    const suggestion = suggestions.find((s) => s.dayOfWeek === dayOfWeek)
+    if (suggestion) {
+      setRejectedRecipeIds((prev) => [...prev, suggestion.recipeId])
+    }
+    setDecisions((prev) => new Map(prev).set(dayOfWeek, 'reject'))
+  }
+
+  const handleRegenerate = async (dayOfWeek: number) => {
+    const suggestion = suggestions.find((s) => s.dayOfWeek === dayOfWeek)
+    if (!suggestion) return
+
+    setRegeneratingDay(dayOfWeek)
+    try {
+      await generateSuggestions([dayOfWeek], [suggestion.recipeId])
+    } finally {
+      setRegeneratingDay(null)
+    }
+  }
+
+  const handleRedoAll = () => {
+    setRejectedRecipeIds([])
+    setDecisions(new Map())
+    setContext(null) // Force refetch context with new feedback
+    generateSuggestions()
+  }
+
+  const handleSave = async () => {
+    const acceptedSuggestions = suggestions.filter(
+      (s) => decisions.get(s.dayOfWeek) === 'accept'
+    )
+
+    if (acceptedSuggestions.length === 0) {
+      toast.error('No meals accepted to save')
+      return
+    }
+
+    setStatus('saving')
+
+    try {
+      // Save each accepted meal sequentially
+      let savedCount = 0
+      let importedCount = 0
+
+      for (const suggestion of acceptedSuggestions) {
+        let recipeId = suggestion.recipeId
+
+        // If it's a web recipe, import it first
+        if (suggestion.isWebRecipe && suggestion.webRecipeUrl) {
+          const importResponse = await fetch('/api/recipes/import', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ url: suggestion.webRecipeUrl }),
+          })
+
+          if (!importResponse.ok) {
+            const err = await importResponse.json()
+            throw new Error(err.error || `Failed to import ${suggestion.recipeTitle}`)
+          }
+
+          const importedRecipe = await importResponse.json()
+          recipeId = importedRecipe.id
+          importedCount++
+        }
+
+        // Now save to meal plan
+        const response = await fetch('/api/planned-meals', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            mealPlanId,
+            recipeId,
+            dayOfWeek: suggestion.dayOfWeek,
+            mealType: 'DINNER',
+            role: 'MAIN',
+          }),
+        })
+
+        if (!response.ok) {
+          const err = await response.json()
+          throw new Error(err.error || `Failed to save ${suggestion.recipeTitle}`)
+        }
+
+        savedCount++
+      }
+
+      const message = importedCount > 0
+        ? `Saved ${savedCount} meal${savedCount > 1 ? 's' : ''} (${importedCount} imported from web)`
+        : `Saved ${savedCount} meal${savedCount > 1 ? 's' : ''}`
+
+      toast.success(message)
+      onComplete()
+      onOpenChange(false)
+    } catch (err) {
+      console.error('Save error:', err)
+      toast.error(err instanceof Error ? err.message : 'Failed to save meals')
+      setStatus('ready')
+    }
+  }
+
+  const acceptedCount = Array.from(decisions.values()).filter((d) => d === 'accept').length
+  const totalSuggestions = suggestions.length
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-lg max-h-[85vh] flex flex-col">
+        <DialogHeader className="flex flex-row items-center justify-between shrink-0">
+          <DialogTitle className="flex items-center gap-2">
+            <Sparkles className="h-5 w-5 text-primary" />
+            Suggested Meals
+          </DialogTitle>
+          {status === 'ready' && (
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={handleRedoAll}
+              className="gap-1.5 -mr-2"
+            >
+              <RefreshCw className="h-4 w-4" />
+              Redo
+            </Button>
+          )}
+        </DialogHeader>
+
+        {/* Feedback input for redo */}
+        {status === 'ready' && (
+          <div className="shrink-0">
+            <Textarea
+              placeholder="Feedback for redo (optional)..."
+              value={feedbackText}
+              onChange={(e) => setFeedbackText(e.target.value)}
+              className="min-h-[60px] text-sm resize-none"
+            />
+          </div>
+        )}
+
+        {/* Content area */}
+        <div className="flex-1 overflow-auto py-2">
+          {status === 'loading' && (
+            <div className="flex flex-col items-center justify-center py-12 gap-3">
+              <Loader2 className="h-8 w-8 animate-spin text-primary" />
+              <p className="text-sm text-muted-foreground">Generating meal suggestions...</p>
+            </div>
+          )}
+
+          {status === 'error' && (
+            <div className="flex flex-col items-center justify-center py-12 gap-3 text-center">
+              <AlertCircle className="h-8 w-8 text-destructive" />
+              <p className="text-sm text-destructive">{error}</p>
+              <Button variant="outline" size="sm" onClick={() => generateSuggestions()}>
+                Try again
+              </Button>
+            </div>
+          )}
+
+          {status === 'ready' && (
+            <div className="space-y-3">
+              {/* Show existing meals */}
+              {existingMeals.length > 0 && (
+                <div className="space-y-2">
+                  {existingMeals.map((meal) => (
+                    <div
+                      key={meal.dayOfWeek}
+                      className="rounded-lg border border-dashed bg-muted/30 p-4"
+                    >
+                      <span className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+                        {DAYS_OF_WEEK[meal.dayOfWeek].slice(0, 3)}
+                      </span>
+                      <p className="text-sm text-muted-foreground mt-1">
+                        Already planned: {meal.title}
+                      </p>
+                    </div>
+                  ))}
+                </div>
+              )}
+
+              {/* Show suggestions */}
+              {suggestions.map((suggestion) => (
+                <AISuggestionCard
+                  key={suggestion.dayOfWeek}
+                  suggestion={suggestion}
+                  decision={decisions.get(suggestion.dayOfWeek) || 'pending'}
+                  onAccept={() => handleAccept(suggestion.dayOfWeek)}
+                  onReject={() => handleReject(suggestion.dayOfWeek)}
+                  onRegenerate={() => handleRegenerate(suggestion.dayOfWeek)}
+                  isRegenerating={regeneratingDay === suggestion.dayOfWeek}
+                />
+              ))}
+            </div>
+          )}
+
+          {status === 'saving' && (
+            <div className="flex flex-col items-center justify-center py-12 gap-3">
+              <Loader2 className="h-8 w-8 animate-spin text-primary" />
+              <p className="text-sm text-muted-foreground">Saving meals to your plan...</p>
+            </div>
+          )}
+        </div>
+
+        {/* Footer */}
+        {status === 'ready' && (
+          <div className="flex items-center justify-between pt-4 border-t shrink-0">
+            <span className="text-sm text-muted-foreground">
+              Accepted: {acceptedCount}/{totalSuggestions}
+            </span>
+            <Button
+              onClick={handleSave}
+              disabled={acceptedCount === 0}
+              className="gap-2"
+            >
+              <Save className="h-4 w-4" />
+              Save Accepted Meals
+            </Button>
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/components/ai-planner/ai-suggestion-card.tsx
+++ b/components/ai-planner/ai-suggestion-card.tsx
@@ -1,8 +1,9 @@
 'use client'
 
+import Image from 'next/image'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
-import { Check, X, RefreshCw, Loader2, Globe, ExternalLink } from 'lucide-react'
+import { Check, X, RefreshCw, Loader2, Globe, ExternalLink, UtensilsCrossed } from 'lucide-react'
 import type { AISuggestionCardProps } from '@/lib/ai-planner/types'
 
 const DAYS_OF_WEEK = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']
@@ -22,13 +23,32 @@ export function AISuggestionCard({
   return (
     <div
       className={`
-        rounded-lg border p-4 transition-all
+        rounded-lg border p-4 md:p-5 transition-all
         ${isAccepted ? 'border-green-500/50 bg-green-50/50 dark:bg-green-950/20' : ''}
         ${isRejected ? 'border-muted bg-muted/30' : ''}
         ${isPending ? 'border-border' : ''}
       `}
     >
-      <div className="flex items-start justify-between gap-3">
+      <div className="flex items-start gap-3 md:gap-4">
+        {/* Recipe image */}
+        <div className="shrink-0">
+          {suggestion.imageUrl ? (
+            <div className="relative w-16 h-16 md:w-24 md:h-24 rounded-md overflow-hidden">
+              <Image
+                src={suggestion.imageUrl}
+                alt={suggestion.recipeTitle}
+                fill
+                className={`object-cover ${isRejected ? 'opacity-50 grayscale' : ''}`}
+                sizes="(min-width: 768px) 96px, 64px"
+              />
+            </div>
+          ) : (
+            <div className={`w-16 h-16 md:w-24 md:h-24 rounded-md bg-muted flex items-center justify-center ${isRejected ? 'opacity-50' : ''}`}>
+              <UtensilsCrossed className="h-6 w-6 md:h-8 md:w-8 text-muted-foreground" />
+            </div>
+          )}
+        </div>
+
         <div className="flex-1 min-w-0">
           {/* Day label */}
           <div className="flex items-center gap-2 mb-1">
@@ -46,7 +66,7 @@ export function AISuggestionCard({
           {/* Recipe title */}
           <h4
             className={`
-              font-medium leading-tight flex items-center gap-1.5
+              font-medium leading-tight flex items-center gap-1.5 md:text-lg
               ${isRejected ? 'line-through text-muted-foreground' : ''}
             `}
           >
@@ -80,7 +100,7 @@ export function AISuggestionCard({
         </div>
 
         {/* Action buttons */}
-        <div className="flex items-center gap-1 shrink-0">
+        <div className="flex items-start gap-1 shrink-0">
           {isPending && (
             <>
               <Button

--- a/components/ai-planner/ai-suggestion-card.tsx
+++ b/components/ai-planner/ai-suggestion-card.tsx
@@ -1,0 +1,147 @@
+'use client'
+
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import { Check, X, RefreshCw, Loader2, Globe, ExternalLink } from 'lucide-react'
+import type { AISuggestionCardProps } from '@/lib/ai-planner/types'
+
+const DAYS_OF_WEEK = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']
+
+export function AISuggestionCard({
+  suggestion,
+  decision,
+  onAccept,
+  onReject,
+  onRegenerate,
+  isRegenerating,
+}: AISuggestionCardProps) {
+  const isAccepted = decision === 'accept'
+  const isRejected = decision === 'reject'
+  const isPending = decision === 'pending'
+
+  return (
+    <div
+      className={`
+        rounded-lg border p-4 transition-all
+        ${isAccepted ? 'border-green-500/50 bg-green-50/50 dark:bg-green-950/20' : ''}
+        ${isRejected ? 'border-muted bg-muted/30' : ''}
+        ${isPending ? 'border-border' : ''}
+      `}
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex-1 min-w-0">
+          {/* Day label */}
+          <div className="flex items-center gap-2 mb-1">
+            <span className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+              {DAYS_OF_WEEK[suggestion.dayOfWeek]}
+            </span>
+            <ConfidenceBadge confidence={suggestion.confidence} />
+            {suggestion.isWebRecipe && (
+              <Badge variant="outline" className="text-[10px] px-1.5 py-0 h-4 bg-blue-100 text-blue-700 border-blue-200">
+                <Globe className="h-2.5 w-2.5 mr-0.5" />
+                Web
+              </Badge>
+            )}
+          </div>
+
+          {/* Recipe title */}
+          <h4
+            className={`
+              font-medium leading-tight flex items-center gap-1.5
+              ${isRejected ? 'line-through text-muted-foreground' : ''}
+            `}
+          >
+            {suggestion.recipeTitle}
+            {suggestion.isWebRecipe && suggestion.webRecipeUrl && !isRejected && (
+              <a
+                href={suggestion.webRecipeUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-muted-foreground hover:text-primary"
+                onClick={(e) => e.stopPropagation()}
+              >
+                <ExternalLink className="h-3.5 w-3.5" />
+              </a>
+            )}
+          </h4>
+
+          {/* Source for web recipes */}
+          {suggestion.isWebRecipe && suggestion.webRecipeSource && !isRejected && (
+            <p className="text-xs text-muted-foreground">
+              from {suggestion.webRecipeSource}
+            </p>
+          )}
+
+          {/* Reason */}
+          {!isRejected && (
+            <p className="text-sm text-muted-foreground mt-1 leading-snug">
+              {suggestion.reason}
+            </p>
+          )}
+        </div>
+
+        {/* Action buttons */}
+        <div className="flex items-center gap-1 shrink-0">
+          {isPending && (
+            <>
+              <Button
+                size="icon"
+                variant="ghost"
+                className="h-8 w-8 text-green-600 hover:text-green-700 hover:bg-green-100"
+                onClick={onAccept}
+              >
+                <Check className="h-4 w-4" />
+              </Button>
+              <Button
+                size="icon"
+                variant="ghost"
+                className="h-8 w-8 text-red-600 hover:text-red-700 hover:bg-red-100"
+                onClick={onReject}
+              >
+                <X className="h-4 w-4" />
+              </Button>
+            </>
+          )}
+
+          {isAccepted && (
+            <Badge variant="outline" className="bg-green-100 text-green-700 border-green-300">
+              <Check className="h-3 w-3 mr-1" />
+              Accepted
+            </Badge>
+          )}
+
+          {isRejected && (
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={onRegenerate}
+              disabled={isRegenerating}
+              className="gap-1.5"
+            >
+              {isRegenerating ? (
+                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+              ) : (
+                <RefreshCw className="h-3.5 w-3.5" />
+              )}
+              New suggestion
+            </Button>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function ConfidenceBadge({ confidence }: { confidence: 'high' | 'medium' | 'low' }) {
+  const colors = {
+    high: 'bg-green-100 text-green-700 border-green-200',
+    medium: 'bg-yellow-100 text-yellow-700 border-yellow-200',
+    low: 'bg-orange-100 text-orange-700 border-orange-200',
+  }
+
+  return (
+    <Badge variant="outline" className={`text-[10px] px-1.5 py-0 h-4 ${colors[confidence]}`}>
+      {confidence}
+    </Badge>
+  )
+}

--- a/components/ai-planner/ai-suggestion-card.tsx
+++ b/components/ai-planner/ai-suggestion-card.tsx
@@ -35,7 +35,6 @@ export function AISuggestionCard({
             <span className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
               {DAYS_OF_WEEK[suggestion.dayOfWeek]}
             </span>
-            <ConfidenceBadge confidence={suggestion.confidence} />
             {suggestion.isWebRecipe && (
               <Badge variant="outline" className="text-[10px] px-1.5 py-0 h-4 bg-blue-100 text-blue-700 border-blue-200">
                 <Globe className="h-2.5 w-2.5 mr-0.5" />
@@ -129,19 +128,5 @@ export function AISuggestionCard({
         </div>
       </div>
     </div>
-  )
-}
-
-function ConfidenceBadge({ confidence }: { confidence: 'high' | 'medium' | 'low' }) {
-  const colors = {
-    high: 'bg-green-100 text-green-700 border-green-200',
-    medium: 'bg-yellow-100 text-yellow-700 border-yellow-200',
-    low: 'bg-orange-100 text-orange-700 border-orange-200',
-  }
-
-  return (
-    <Badge variant="outline" className={`text-[10px] px-1.5 py-0 h-4 ${colors[confidence]}`}>
-      {confidence}
-    </Badge>
   )
 }

--- a/components/ai-planner/index.ts
+++ b/components/ai-planner/index.ts
@@ -1,0 +1,3 @@
+export { AIPlanButton } from './ai-plan-button'
+export { AIPlanModal } from './ai-plan-modal'
+export { AISuggestionCard } from './ai-suggestion-card'

--- a/components/week-view.tsx
+++ b/components/week-view.tsx
@@ -9,6 +9,7 @@ import { MealSlot } from '@/components/meal-slot'
 import { RecipePicker } from '@/components/recipe-picker'
 import { LunchboxPicker, type LunchboxItem, type FamilyMember, type LunchboxSuggestion } from '@/components/lunchbox-picker'
 import { PlannerSuggestions } from '@/components/planner-suggestions'
+import { AIPlanButton } from '@/components/ai-planner'
 import { CalendarEventBadge } from '@/components/calendar-event-badge'
 import { CalendarEventsDialog } from '@/components/calendar-events-dialog'
 import type { WeekCalendarData } from '@/lib/google-calendar'
@@ -466,6 +467,32 @@ export function WeekView({ recipes, familyMembers }: WeekViewProps) {
           </Button>
         )}
       </div>
+
+      {/* AI Plan Button - shown when there are empty dinner slots */}
+      {!isLoading && (
+        <div className="flex justify-center">
+          <AIPlanButton
+            weekStart={weekStart}
+            mealPlanId={mealPlan?.id || null}
+            existingMeals={
+              mealPlan?.plannedMeals
+                .filter((m) => m.mealType === 'DINNER' && !m.familyMemberId)
+                .map((m) => ({
+                  dayOfWeek: m.dayOfWeek,
+                  recipeId: m.recipes.find((r) => r.role === 'MAIN')?.recipe?.id,
+                  title:
+                    m.recipes.find((r) => r.role === 'MAIN')?.recipe?.title ||
+                    m.placeholderTitle ||
+                    'Planned meal',
+                })) || []
+            }
+            onSuggestionsAccepted={() => {
+              fetchMealPlan()
+              router.refresh()
+            }}
+          />
+        </div>
+      )}
 
       {/* Calendar Grid */}
       {isLoading ? (

--- a/lib/ai-planner/prompt.ts
+++ b/lib/ai-planner/prompt.ts
@@ -1,0 +1,206 @@
+import type { PlannerContext, AISuggestion } from './types'
+
+const DAYS_OF_WEEK = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday']
+
+export const SYSTEM_PROMPT = `You are a family meal planning assistant. Your job is to suggest dinner recipes based on family preferences, what's expiring in their kitchen, and any specific requests.
+
+Guidelines:
+- Prioritize recipes from the user's AVAILABLE RECIPES list (these are known family favorites)
+- NEVER suggest recipes that kids have downvoted - these are marked in the "AVOID" list
+- Avoid recipes made in the last 2 weeks unless there are limited options
+- Prioritize recipes that use expiring perishables
+- Balance variety across the week (don't suggest similar cuisines back-to-back)
+- Consider the user's specific requests (easy meals on busy days, guests, etc.)
+- Keep reasons to 1-2 concise sentences explaining why this recipe fits
+- If WEB RECIPES are provided, you may suggest them when they're a better fit than available recipes (e.g., uses expiring ingredients, matches user request, adds variety)
+
+Confidence levels:
+- "high": Recipe is a family favorite, uses expiring ingredients, or perfectly matches user request
+- "medium": Good fit but not perfect (recently made, or partial match to preferences)
+- "low": Only option available, or compromises needed
+
+CRITICAL: Only suggest recipes from "AVAILABLE RECIPES" or "WEB RECIPES" lists. Never invent recipes.
+
+Respond with valid JSON matching this schema:
+{
+  "suggestions": [
+    {
+      "dayOfWeek": <number 0-6 where 0=Monday>,
+      "recipeId": "<recipe ID from AVAILABLE RECIPES, or URL from WEB RECIPES>",
+      "recipeTitle": "<exact recipe title>",
+      "reason": "<1-2 sentence explanation>",
+      "confidence": "high" | "medium" | "low",
+      "isWebRecipe": <true if from WEB RECIPES, false or omit if from AVAILABLE RECIPES>
+    }
+  ]
+}`
+
+export function buildUserPrompt(
+  context: PlannerContext,
+  daysToGenerate: number[],
+  userPrompt?: string,
+  excludeRecipeIds?: string[]
+): string {
+  const lines: string[] = []
+
+  // Days needed
+  const dayNames = daysToGenerate.map((d) => DAYS_OF_WEEK[d]).join(', ')
+  lines.push(`Generate dinner suggestions for: ${dayNames}`)
+  lines.push(`(Day numbers: ${daysToGenerate.join(', ')} where 0=Monday, 6=Sunday)`)
+  lines.push('')
+
+  // Family members
+  if (context.family.members.length > 0) {
+    const memberList = context.family.members
+      .map((m) => `${m.name} (${m.role})`)
+      .join(', ')
+    lines.push(`FAMILY: ${memberList}`)
+    lines.push('')
+  }
+
+  // Available recipes (excluding any previously rejected this session)
+  const availableRecipes = context.preferences.favoriteRecipes.filter(
+    (r) => !excludeRecipeIds?.includes(r.id)
+  )
+
+  if (availableRecipes.length > 0) {
+    lines.push('AVAILABLE RECIPES (sorted by preference score):')
+    for (const recipe of availableRecipes) {
+      const tags = recipe.tags.length > 0 ? recipe.tags.join(', ') : 'no tags'
+      const lastUsed = recipe.daysSinceUsed !== null
+        ? `${recipe.daysSinceUsed} days ago`
+        : 'never made'
+      lines.push(
+        `- ID: ${recipe.id} | "${recipe.title}" | Tags: ${tags} | Score: ${recipe.score} | Last: ${lastUsed}`
+      )
+    }
+    lines.push('')
+  } else {
+    lines.push('AVAILABLE RECIPES: None available (all filtered out)')
+    lines.push('')
+  }
+
+  // Recipes to avoid
+  if (context.preferences.avoidRecipes.length > 0) {
+    const avoidList = context.preferences.avoidRecipes
+      .map((r) => `"${r.title}"`)
+      .join(', ')
+    lines.push(`AVOID (kids don't like): ${avoidList}`)
+    lines.push('')
+  }
+
+  // Recently made
+  if (context.recentMeals.length > 0) {
+    const recentList = context.recentMeals
+      .map((m) => `"${m.title}" (${m.weeksAgo === 0 ? 'this week' : `${m.weeksAgo} week${m.weeksAgo > 1 ? 's' : ''} ago`})`)
+      .join(', ')
+    lines.push(`RECENTLY MADE: ${recentList}`)
+    lines.push('')
+  }
+
+  // Expiring perishables
+  if (context.perishables.length > 0) {
+    const perishableList = context.perishables
+      .map((p) => `${p.name} (${p.daysUntilExpiration} day${p.daysUntilExpiration !== 1 ? 's' : ''})`)
+      .join(', ')
+    lines.push(`EXPIRING SOON: ${perishableList}`)
+    lines.push('')
+  }
+
+  // Already planned meals
+  if (context.existingMeals.length > 0) {
+    lines.push('ALREADY PLANNED THIS WEEK:')
+    for (const meal of context.existingMeals) {
+      lines.push(`- ${DAYS_OF_WEEK[meal.dayOfWeek]}: "${meal.title}"`)
+    }
+    lines.push('')
+  }
+
+  // Web recipes (from search)
+  if (context.webRecipes && context.webRecipes.length > 0) {
+    lines.push('WEB RECIPES (can be imported - use URL as recipeId, set isWebRecipe: true):')
+    for (const recipe of context.webRecipes) {
+      lines.push(`- URL: ${recipe.url} | "${recipe.title}" | ${recipe.source}`)
+      if (recipe.snippet) {
+        lines.push(`  ${recipe.snippet.slice(0, 150)}...`)
+      }
+    }
+    lines.push('')
+  }
+
+  // User's specific request
+  if (userPrompt && userPrompt.trim()) {
+    lines.push(`USER REQUEST: ${userPrompt.trim()}`)
+    lines.push('')
+  }
+
+  // Final instruction
+  lines.push('Respond with JSON only. No explanation text before or after the JSON.')
+
+  return lines.join('\n')
+}
+
+export function parseAIResponse(responseText: string): AISuggestion[] {
+  // Try to extract JSON from the response
+  let jsonText = responseText.trim()
+
+  // Sometimes the model wraps in markdown code blocks
+  const jsonMatch = jsonText.match(/```(?:json)?\s*([\s\S]*?)```/)
+  if (jsonMatch) {
+    jsonText = jsonMatch[1].trim()
+  }
+
+  // Parse the JSON
+  const parsed = JSON.parse(jsonText)
+
+  if (!parsed.suggestions || !Array.isArray(parsed.suggestions)) {
+    throw new Error('Invalid response format: missing suggestions array')
+  }
+
+  // Validate each suggestion
+  const suggestions: AISuggestion[] = []
+  for (const s of parsed.suggestions) {
+    if (
+      typeof s.dayOfWeek !== 'number' ||
+      s.dayOfWeek < 0 ||
+      s.dayOfWeek > 6
+    ) {
+      throw new Error(`Invalid dayOfWeek: ${s.dayOfWeek}`)
+    }
+
+    if (typeof s.recipeId !== 'string' || !s.recipeId) {
+      throw new Error('Invalid or missing recipeId')
+    }
+
+    if (typeof s.recipeTitle !== 'string' || !s.recipeTitle) {
+      throw new Error('Invalid or missing recipeTitle')
+    }
+
+    const suggestion: AISuggestion = {
+      dayOfWeek: s.dayOfWeek,
+      recipeId: s.recipeId,
+      recipeTitle: s.recipeTitle,
+      reason: typeof s.reason === 'string' ? s.reason : 'AI suggestion',
+      confidence: ['high', 'medium', 'low'].includes(s.confidence)
+        ? s.confidence
+        : 'medium',
+    }
+
+    // Handle web recipes
+    if (s.isWebRecipe === true) {
+      suggestion.isWebRecipe = true
+      suggestion.webRecipeUrl = s.recipeId // URL is stored in recipeId for web recipes
+      // Extract source from URL
+      try {
+        const url = new URL(s.recipeId)
+        suggestion.webRecipeSource = url.hostname.replace('www.', '')
+      } catch {
+        suggestion.webRecipeSource = 'web'
+      }
+    }
+
+    suggestions.push(suggestion)
+  }
+
+  return suggestions
+}

--- a/lib/ai-planner/prompt.ts
+++ b/lib/ai-planner/prompt.ts
@@ -10,6 +10,7 @@ Guidelines:
 - Avoid recipes made in the last 2 weeks unless there are limited options
 - Prioritize recipes that use expiring perishables
 - Balance variety across the week (don't suggest similar cuisines back-to-back)
+- Don't repeat the same recipe twice in one week - check ALREADY PLANNED THIS WEEK and your own suggestions to ensure each recipe is only used once
 - Consider the user's specific requests (easy meals on busy days, guests, etc.)
 - WEEKNIGHT RULE: Monday-Thursday meals should be quick and simple (under 30-40 min total). Save complex or time-intensive recipes for Friday-Sunday.
 - Keep reasons to 1-2 concise sentences explaining why this recipe fits

--- a/lib/ai-planner/prompt.ts
+++ b/lib/ai-planner/prompt.ts
@@ -11,6 +11,7 @@ Guidelines:
 - Prioritize recipes that use expiring perishables
 - Balance variety across the week (don't suggest similar cuisines back-to-back)
 - Consider the user's specific requests (easy meals on busy days, guests, etc.)
+- WEEKNIGHT RULE: Monday-Thursday meals should be quick and simple (under 30-40 min total). Save complex or time-intensive recipes for Friday-Sunday.
 - Keep reasons to 1-2 concise sentences explaining why this recipe fits
 - If WEB RECIPES are provided, you may suggest them when they're a better fit than available recipes (e.g., uses expiring ingredients, matches user request, adds variety)
 

--- a/lib/ai-planner/types.ts
+++ b/lib/ai-planner/types.ts
@@ -17,6 +17,7 @@ export interface FavoriteRecipeContext {
   tags: string[]
   score: number
   daysSinceUsed: number | null
+  imageUrl?: string | null
 }
 
 export interface AvoidRecipeContext {
@@ -45,6 +46,7 @@ export interface WebRecipeContext {
   title: string
   snippet: string
   source: string
+  imageUrl?: string | null
 }
 
 export interface PlannerContext {
@@ -81,6 +83,7 @@ export interface AISuggestion {
   recipeTitle: string
   reason: string
   confidence: ConfidenceLevel
+  imageUrl?: string | null
   // For web recipes that need to be imported
   isWebRecipe?: boolean
   webRecipeUrl?: string

--- a/lib/ai-planner/types.ts
+++ b/lib/ai-planner/types.ts
@@ -1,0 +1,159 @@
+// AI Planner TypeScript Interfaces
+
+import { FamilyRole } from '@prisma/client'
+
+// ============================================================================
+// Context Types - Input to AI generation
+// ============================================================================
+
+export interface FamilyMemberContext {
+  name: string
+  role: FamilyRole
+}
+
+export interface FavoriteRecipeContext {
+  id: string
+  title: string
+  tags: string[]
+  score: number
+  daysSinceUsed: number | null
+}
+
+export interface AvoidRecipeContext {
+  id: string
+  title: string
+  kidDownVotes: number
+}
+
+export interface RecentMealContext {
+  title: string
+  weeksAgo: number
+}
+
+export interface PerishableContext {
+  name: string
+  daysUntilExpiration: number
+}
+
+export interface ExistingMealContext {
+  dayOfWeek: number
+  title: string
+}
+
+export interface WebRecipeContext {
+  url: string
+  title: string
+  snippet: string
+  source: string
+}
+
+export interface PlannerContext {
+  family: {
+    members: FamilyMemberContext[]
+  }
+  preferences: {
+    favoriteRecipes: FavoriteRecipeContext[]
+    avoidRecipes: AvoidRecipeContext[]
+    preferredTags: string[]
+  }
+  recentMeals: RecentMealContext[]
+  perishables: PerishableContext[]
+  existingMeals: ExistingMealContext[]
+  webRecipes?: WebRecipeContext[]
+}
+
+// ============================================================================
+// Generation Request/Response Types
+// ============================================================================
+
+export interface GenerateRequest {
+  context: PlannerContext
+  userPrompt?: string
+  daysToGenerate: number[]
+  excludeRecipeIds?: string[]
+}
+
+export type ConfidenceLevel = 'high' | 'medium' | 'low'
+
+export interface AISuggestion {
+  dayOfWeek: number
+  recipeId: string
+  recipeTitle: string
+  reason: string
+  confidence: ConfidenceLevel
+  // For web recipes that need to be imported
+  isWebRecipe?: boolean
+  webRecipeUrl?: string
+  webRecipeSource?: string
+}
+
+export interface GenerateResponse {
+  suggestions: AISuggestion[]
+  usage: {
+    inputTokens: number
+    outputTokens: number
+  }
+}
+
+// ============================================================================
+// UI State Types
+// ============================================================================
+
+export type DecisionStatus = 'pending' | 'accept' | 'reject'
+
+export type ModalStatus = 'idle' | 'loading' | 'ready' | 'saving' | 'error'
+
+export interface AIPlannerModalState {
+  status: ModalStatus
+  suggestions: AISuggestion[]
+  decisions: Map<number, DecisionStatus>
+  rejectedRecipeIds: string[]
+  feedbackText: string
+  error: string | null
+}
+
+// ============================================================================
+// Component Props Types
+// ============================================================================
+
+export interface ExistingMealInfo {
+  dayOfWeek: number
+  recipeId?: string
+  title: string
+}
+
+export interface AIPlanButtonProps {
+  weekStart: Date
+  mealPlanId: string | null
+  existingMeals: ExistingMealInfo[]
+  onSuggestionsAccepted: () => void
+}
+
+export interface AIPlanModalProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  weekStart: Date
+  mealPlanId: string
+  userPrompt?: string
+  existingMeals: ExistingMealInfo[]
+  onComplete: () => void
+}
+
+export interface AISuggestionCardProps {
+  suggestion: AISuggestion
+  decision: DecisionStatus
+  onAccept: () => void
+  onReject: () => void
+  onRegenerate: () => void
+  isRegenerating: boolean
+}
+
+// ============================================================================
+// API Error Types
+// ============================================================================
+
+export interface APIError {
+  error: string
+  code?: string
+  details?: string
+}

--- a/lib/ai-planner/web-search.ts
+++ b/lib/ai-planner/web-search.ts
@@ -1,10 +1,13 @@
-// Web recipe search using DuckDuckGo (no API key required)
+// Web recipe search using Brave Search API
+
+import Anthropic from '@anthropic-ai/sdk'
 
 export interface WebRecipeResult {
   title: string
   url: string
   snippet: string
   source: string
+  imageUrl?: string | null
 }
 
 export interface WebSearchResponse {
@@ -23,37 +26,68 @@ const RECIPE_SITES = [
   'delish.com',
 ]
 
+interface BraveSearchResult {
+  title: string
+  url: string
+  description: string
+  thumbnail?: {
+    src: string
+  }
+}
+
+interface BraveSearchResponse {
+  web?: {
+    results: BraveSearchResult[]
+  }
+}
+
 /**
- * Search for recipes using DuckDuckGo HTML (no API key needed)
+ * Search for recipes using Brave Search API
  */
 export async function searchWebRecipes(
   query: string,
   limit: number = 5
 ): Promise<WebSearchResponse> {
+  const apiKey = process.env.BRAVE_SEARCH_API_KEY
+
+  if (!apiKey) {
+    console.error('BRAVE_SEARCH_API_KEY not configured')
+    return { results: [], searchQuery: query }
+  }
+
   try {
     // Add recipe sites to query for better results
     const siteQuery = RECIPE_SITES.slice(0, 3).map(s => `site:${s}`).join(' OR ')
     const fullQuery = `${query} recipe (${siteQuery})`
 
-    const url = `https://html.duckduckgo.com/html/?q=${encodeURIComponent(fullQuery)}`
+    const url = new URL('https://api.search.brave.com/res/v1/web/search')
+    url.searchParams.set('q', fullQuery)
+    url.searchParams.set('count', '20') // Fetch more to filter with LLM
 
-    const response = await fetch(url, {
+    const response = await fetch(url.toString(), {
       headers: {
-        'User-Agent': 'Mozilla/5.0 (compatible; FamilyTable/1.0)',
+        'Accept': 'application/json',
+        'X-Subscription-Token': apiKey,
       },
     })
 
     if (!response.ok) {
-      console.error('DuckDuckGo search failed:', response.status)
+      console.error('Brave search failed:', response.status, await response.text())
       return { results: [], searchQuery: query }
     }
 
-    const html = await response.text()
+    const data: BraveSearchResponse = await response.json()
 
-    // Parse results from HTML
-    const results = parseSearchResults(html, limit)
+    // Parse results from recipe sites
+    const candidates = parseSearchResults(data, 20)
 
-    console.log(`Web search for "${query}" found ${results.length} recipes`)
+    // Use LLM to filter out roundup/listicle pages
+    const filtered = await filterWithLLM(candidates)
+
+    // Return requested limit
+    const results = filtered.slice(0, limit)
+
+    console.log(`Web search for "${query}": ${candidates.length} candidates -> ${filtered.length} valid -> ${results.length} returned`)
 
     return { results, searchQuery: query }
   } catch (error) {
@@ -63,61 +97,105 @@ export async function searchWebRecipes(
 }
 
 /**
- * Parse search results from DuckDuckGo HTML
+ * Use LLM to filter out roundup/listicle pages, keeping only single-recipe URLs
  */
-function parseSearchResults(html: string, limit: number): WebRecipeResult[] {
+async function filterWithLLM(candidates: WebRecipeResult[]): Promise<WebRecipeResult[]> {
+  if (candidates.length === 0) {
+    return []
+  }
+
+  // Skip LLM filtering if Anthropic not configured
+  if (!process.env.ANTHROPIC_API_KEY) {
+    console.warn('ANTHROPIC_API_KEY not configured, skipping LLM filter')
+    return candidates
+  }
+
+  try {
+    const anthropic = new Anthropic()
+
+    // Build compact list for LLM
+    const candidateList = candidates.map((c, i) =>
+      `${i + 1}. "${c.title}" - ${c.url}${c.snippet ? ` | ${c.snippet.slice(0, 100)}` : ''}`
+    ).join('\n')
+
+    const response = await anthropic.messages.create({
+      model: 'claude-haiku-4-5-20251001',
+      max_tokens: 256,
+      messages: [{
+        role: 'user',
+        content: `Filter this list to ONLY include URLs that link to a SINGLE recipe page.
+
+EXCLUDE:
+- Roundup/listicle pages ("25 best dinners", "easy weeknight meal ideas")
+- Gallery/collection pages listing multiple recipes
+- Category or index pages
+
+INCLUDE:
+- Pages for ONE specific recipe (e.g., "Honey Garlic Chicken", "Sheet Pan Salmon")
+
+${candidateList}
+
+Return JSON with the numbers of valid single-recipe pages: {"valid": [1, 3, 5]}`
+      }]
+    })
+
+    const text = response.content[0]
+    if (text.type !== 'text') {
+      return candidates
+    }
+
+    // Parse response
+    const match = text.text.match(/\{[\s\S]*"valid"[\s\S]*\[[\s\S]*\][\s\S]*\}/)
+    if (!match) {
+      console.warn('LLM filter returned unexpected format:', text.text)
+      return candidates
+    }
+
+    const parsed = JSON.parse(match[0])
+    const validIndices = new Set(parsed.valid.map((n: number) => n - 1)) // Convert to 0-indexed
+
+    return candidates.filter((_, i) => validIndices.has(i))
+  } catch (error) {
+    console.error('LLM filter failed, returning all candidates:', error)
+    return candidates
+  }
+}
+
+/**
+ * Parse search results from Brave Search API response
+ */
+function parseSearchResults(data: BraveSearchResponse, limit: number): WebRecipeResult[] {
   const results: WebRecipeResult[] = []
 
-  // Match result blocks - DuckDuckGo uses class="result__a" for links
-  const linkRegex = /<a[^>]+class="result__a"[^>]+href="([^"]+)"[^>]*>([^<]+)<\/a>/gi
-  const snippetRegex = /<a[^>]+class="result__snippet"[^>]*>([^<]*(?:<[^>]+>[^<]*)*)<\/a>/gi
+  if (!data.web?.results) {
+    return results
+  }
 
-  let linkMatch
-  const links: { url: string; title: string }[] = []
-
-  while ((linkMatch = linkRegex.exec(html)) !== null && links.length < limit * 2) {
-    let url = linkMatch[1]
-    const title = linkMatch[2].trim()
-
-    // DuckDuckGo wraps URLs - extract the actual URL
-    if (url.includes('uddg=')) {
-      const match = url.match(/uddg=([^&]+)/)
-      if (match) {
-        url = decodeURIComponent(match[1])
-      }
-    }
-
+  for (const result of data.web.results) {
     // Only include results from recipe sites
-    if (RECIPE_SITES.some(site => url.includes(site))) {
-      links.push({ url, title })
+    if (!RECIPE_SITES.some(site => result.url.includes(site))) {
+      continue
     }
-  }
-
-  // Get snippets
-  const snippets: string[] = []
-  let snippetMatch
-  while ((snippetMatch = snippetRegex.exec(html)) !== null) {
-    snippets.push(snippetMatch[1].replace(/<[^>]+>/g, '').trim())
-  }
-
-  // Combine links with snippets
-  for (let i = 0; i < Math.min(links.length, limit); i++) {
-    const { url, title } = links[i]
 
     // Extract source domain
     let source = 'web'
     try {
-      source = new URL(url).hostname.replace('www.', '')
+      source = new URL(result.url).hostname.replace('www.', '')
     } catch {
       // Keep default
     }
 
     results.push({
-      title: cleanRecipeTitle(title),
-      url,
-      snippet: snippets[i] || '',
+      title: cleanRecipeTitle(result.title),
+      url: result.url,
+      snippet: result.description || '',
       source,
+      imageUrl: result.thumbnail?.src || null,
     })
+
+    if (results.length >= limit) {
+      break
+    }
   }
 
   return results
@@ -135,34 +213,172 @@ function cleanRecipeTitle(title: string): string {
     .trim()
 }
 
-/**
- * Build search queries based on context
- */
-export function buildSearchQueries(
-  perishables: string[],
-  preferredTags: string[],
+export interface SearchQueryContext {
   userPrompt?: string
-): string[] {
-  const queries: string[] = []
+  perishables: string[]
+  preferredTags: string[]
+  recentMeals: string[]
+  familyNotes?: string // e.g., "2 adults, 1 picky child"
+}
 
-  if (userPrompt) {
-    queries.push(userPrompt)
+/**
+ * Use LLM to generate targeted search queries based on context
+ */
+export async function buildSearchQueries(
+  context: SearchQueryContext
+): Promise<string[]> {
+  // Fallback queries if LLM unavailable
+  const fallbackQueries = ['easy weeknight dinner', 'quick family dinner']
+
+  if (!process.env.ANTHROPIC_API_KEY) {
+    console.warn('ANTHROPIC_API_KEY not configured, using fallback queries')
+    return fallbackQueries
   }
 
-  if (perishables.length > 0) {
-    const perishableQuery = perishables.slice(0, 3).join(' ')
-    queries.push(`easy ${perishableQuery} dinner`)
-  }
+  try {
+    const anthropic = new Anthropic()
 
-  if (preferredTags.length > 0) {
-    const tagQuery = preferredTags.slice(0, 2).join(' ')
-    queries.push(`${tagQuery} dinner`)
-  }
+    const contextLines: string[] = []
 
-  if (queries.length < 2) {
-    queries.push('easy weeknight dinner')
-    queries.push('quick family dinner')
-  }
+    if (context.userPrompt) {
+      contextLines.push(`User request: "${context.userPrompt}"`)
+    }
+    if (context.perishables.length > 0) {
+      contextLines.push(`Expiring ingredients to use: ${context.perishables.join(', ')}`)
+    }
+    if (context.preferredTags.length > 0) {
+      contextLines.push(`Family preferences: ${context.preferredTags.join(', ')}`)
+    }
+    if (context.recentMeals.length > 0) {
+      contextLines.push(`Recently made (avoid similar): ${context.recentMeals.slice(0, 5).join(', ')}`)
+    }
+    if (context.familyNotes) {
+      contextLines.push(`Family: ${context.familyNotes}`)
+    }
 
-  return queries.slice(0, 3)
+    // If no context, return fallbacks
+    if (contextLines.length === 0) {
+      return fallbackQueries
+    }
+
+    const response = await anthropic.messages.create({
+      model: 'claude-haiku-4-5-20251001',
+      max_tokens: 100,
+      messages: [{
+        role: 'user',
+        content: `Generate ONE specific recipe search query based on this context:
+
+${contextLines.join('\n')}
+
+Guidelines:
+- Be specific (e.g., "honey garlic salmon" not "fish dinner")
+- Prioritize using expiring ingredients if listed
+- Target a single recipe, not roundups
+
+Return JSON: {"query": "your search query"}`
+      }]
+    })
+
+    const text = response.content[0]
+    if (text.type !== 'text') {
+      return fallbackQueries
+    }
+
+    const match = text.text.match(/\{[\s\S]*"query"[\s\S]*:[\s\S]*"([^"]+)"[\s\S]*\}/)
+    if (!match) {
+      console.warn('Query generation returned unexpected format:', text.text)
+      return fallbackQueries
+    }
+
+    const query = match[1].trim()
+
+    console.log('LLM generated search query:', query)
+
+    return query.length > 0 ? [query] : fallbackQueries
+  } catch (error) {
+    console.error('Query generation failed, using fallbacks:', error)
+    return fallbackQueries
+  }
+}
+
+/**
+ * Fetch the image URL from a recipe page
+ * Looks for og:image, schema.org image, or twitter:image
+ */
+export async function fetchRecipeImage(url: string): Promise<string | null> {
+  try {
+    const response = await fetch(url, {
+      headers: {
+        'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+      },
+      signal: AbortSignal.timeout(5000), // 5 second timeout
+    })
+
+    if (!response.ok) {
+      return null
+    }
+
+    const html = await response.text()
+
+    // Try og:image first (most common) - handle various attribute orderings
+    let imageUrl: string | null = null
+
+    // Pattern 1: property before content
+    const ogMatch1 = html.match(/<meta\s+property=["']og:image["']\s+content=["']([^"']+)["']/i)
+    if (ogMatch1) {
+      imageUrl = ogMatch1[1]
+    }
+
+    // Pattern 2: content before property
+    if (!imageUrl) {
+      const ogMatch2 = html.match(/<meta\s+content=["']([^"']+)["']\s+property=["']og:image["']/i)
+      if (ogMatch2) {
+        imageUrl = ogMatch2[1]
+      }
+    }
+
+    // Pattern 3: with other attributes in between
+    if (!imageUrl) {
+      const ogMatch3 = html.match(/<meta[^>]+property=["']og:image["'][^>]+content=["']([^"']+)["']/i)
+      if (ogMatch3) {
+        imageUrl = ogMatch3[1]
+      }
+    }
+
+    if (imageUrl) {
+      return imageUrl
+    }
+
+    // Try twitter:image
+    const twitterMatch = html.match(/<meta[^>]+name=["']twitter:image["'][^>]+content=["']([^"']+)["']/i)
+      || html.match(/<meta[^>]+content=["']([^"']+)["'][^>]+name=["']twitter:image["']/i)
+    if (twitterMatch) {
+      return twitterMatch[1]
+    }
+
+    // Try schema.org Recipe image
+    const schemaMatch = html.match(/"image"\s*:\s*"([^"]+)"/i)
+      || html.match(/"image"\s*:\s*\[\s*"([^"]+)"/i)
+    if (schemaMatch) {
+      return schemaMatch[1]
+    }
+
+    return null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Enrich web recipe results with images (fetched in parallel)
+ */
+export async function enrichWithImages(
+  results: WebRecipeResult[]
+): Promise<WebRecipeResult[]> {
+  const imagePromises = results.map(async (result) => {
+    const imageUrl = await fetchRecipeImage(result.url)
+    return { ...result, imageUrl }
+  })
+
+  return Promise.all(imagePromises)
 }

--- a/lib/ai-planner/web-search.ts
+++ b/lib/ai-planner/web-search.ts
@@ -1,0 +1,112 @@
+// Google Custom Search integration for recipe discovery
+
+export interface WebRecipeResult {
+  title: string
+  url: string
+  snippet: string
+  source: string // e.g., "allrecipes.com"
+}
+
+export interface WebSearchResponse {
+  results: WebRecipeResult[]
+  searchQuery: string
+}
+
+/**
+ * Search for recipes using Google Custom Search API
+ */
+export async function searchWebRecipes(
+  query: string,
+  limit: number = 5
+): Promise<WebSearchResponse> {
+  const apiKey = process.env.GOOGLE_SEARCH_API_KEY
+  const searchEngineId = process.env.GOOGLE_SEARCH_ENGINE_ID
+
+  if (!apiKey || !searchEngineId) {
+    console.warn('Google Search API not configured, skipping web search')
+    return { results: [], searchQuery: query }
+  }
+
+  try {
+    const params = new URLSearchParams({
+      key: apiKey,
+      cx: searchEngineId,
+      q: `${query} recipe`,
+      num: String(Math.min(limit, 10)), // Google API max is 10
+    })
+
+    const response = await fetch(
+      `https://www.googleapis.com/customsearch/v1?${params}`
+    )
+
+    if (!response.ok) {
+      const error = await response.json().catch(() => ({}))
+      console.error('Google Search API error:', error)
+      return { results: [], searchQuery: query }
+    }
+
+    const data = await response.json()
+
+    const results: WebRecipeResult[] = (data.items || []).map(
+      (item: { title: string; link: string; snippet: string; displayLink: string }) => ({
+        title: cleanRecipeTitle(item.title),
+        url: item.link,
+        snippet: item.snippet || '',
+        source: item.displayLink,
+      })
+    )
+
+    return { results, searchQuery: query }
+  } catch (error) {
+    console.error('Web search failed:', error)
+    return { results: [], searchQuery: query }
+  }
+}
+
+/**
+ * Clean up recipe titles from search results
+ */
+function cleanRecipeTitle(title: string): string {
+  // Remove common suffixes like "| Allrecipes", "- Food Network", etc.
+  return title
+    .replace(/\s*[\|\-–—]\s*(Allrecipes|Food Network|Bon Appétit|Epicurious|Serious Eats|Budget Bytes|Delish|Simply Recipes|Taste of Home|NYT Cooking).*$/i, '')
+    .replace(/\s*Recipe\s*$/i, '')
+    .trim()
+}
+
+/**
+ * Build search queries based on context (perishables, preferences, user request)
+ */
+export function buildSearchQueries(
+  perishables: string[],
+  preferredTags: string[],
+  userPrompt?: string
+): string[] {
+  const queries: string[] = []
+
+  // If user has specific request, prioritize that
+  if (userPrompt) {
+    queries.push(userPrompt)
+  }
+
+  // Build queries from expiring perishables
+  if (perishables.length > 0) {
+    // Combine first 2-3 perishables into a query
+    const perishableQuery = perishables.slice(0, 3).join(' ')
+    queries.push(`easy ${perishableQuery} dinner`)
+  }
+
+  // Build queries from preferred tags
+  if (preferredTags.length > 0) {
+    const tagQuery = preferredTags.slice(0, 2).join(' ')
+    queries.push(`${tagQuery} dinner recipes`)
+  }
+
+  // Add some variety queries if we don't have enough
+  if (queries.length < 2) {
+    queries.push('easy weeknight dinner')
+    queries.push('quick family dinner')
+  }
+
+  return queries.slice(0, 3) // Max 3 queries to limit API calls
+}

--- a/lib/ai-planner/web-search.ts
+++ b/lib/ai-planner/web-search.ts
@@ -1,10 +1,10 @@
-// Google Custom Search integration for recipe discovery
+// Web recipe search using DuckDuckGo (no API key required)
 
 export interface WebRecipeResult {
   title: string
   url: string
   snippet: string
-  source: string // e.g., "allrecipes.com"
+  source: string
 }
 
 export interface WebSearchResponse {
@@ -12,49 +12,48 @@ export interface WebSearchResponse {
   searchQuery: string
 }
 
+const RECIPE_SITES = [
+  'allrecipes.com',
+  'seriouseats.com',
+  'budgetbytes.com',
+  'foodnetwork.com',
+  'bonappetit.com',
+  'epicurious.com',
+  'simplyrecipes.com',
+  'delish.com',
+]
+
 /**
- * Search for recipes using Google Custom Search API
+ * Search for recipes using DuckDuckGo HTML (no API key needed)
  */
 export async function searchWebRecipes(
   query: string,
   limit: number = 5
 ): Promise<WebSearchResponse> {
-  const apiKey = process.env.GOOGLE_SEARCH_API_KEY
-  const searchEngineId = process.env.GOOGLE_SEARCH_ENGINE_ID
-
-  if (!apiKey || !searchEngineId) {
-    console.warn('Google Search API not configured, skipping web search')
-    return { results: [], searchQuery: query }
-  }
-
   try {
-    const params = new URLSearchParams({
-      key: apiKey,
-      cx: searchEngineId,
-      q: `${query} recipe`,
-      num: String(Math.min(limit, 10)), // Google API max is 10
+    // Add recipe sites to query for better results
+    const siteQuery = RECIPE_SITES.slice(0, 3).map(s => `site:${s}`).join(' OR ')
+    const fullQuery = `${query} recipe (${siteQuery})`
+
+    const url = `https://html.duckduckgo.com/html/?q=${encodeURIComponent(fullQuery)}`
+
+    const response = await fetch(url, {
+      headers: {
+        'User-Agent': 'Mozilla/5.0 (compatible; FamilyTable/1.0)',
+      },
     })
 
-    const response = await fetch(
-      `https://www.googleapis.com/customsearch/v1?${params}`
-    )
-
     if (!response.ok) {
-      const error = await response.json().catch(() => ({}))
-      console.error('Google Search API error:', error)
+      console.error('DuckDuckGo search failed:', response.status)
       return { results: [], searchQuery: query }
     }
 
-    const data = await response.json()
+    const html = await response.text()
 
-    const results: WebRecipeResult[] = (data.items || []).map(
-      (item: { title: string; link: string; snippet: string; displayLink: string }) => ({
-        title: cleanRecipeTitle(item.title),
-        url: item.link,
-        snippet: item.snippet || '',
-        source: item.displayLink,
-      })
-    )
+    // Parse results from HTML
+    const results = parseSearchResults(html, limit)
+
+    console.log(`Web search for "${query}" found ${results.length} recipes`)
 
     return { results, searchQuery: query }
   } catch (error) {
@@ -64,18 +63,80 @@ export async function searchWebRecipes(
 }
 
 /**
+ * Parse search results from DuckDuckGo HTML
+ */
+function parseSearchResults(html: string, limit: number): WebRecipeResult[] {
+  const results: WebRecipeResult[] = []
+
+  // Match result blocks - DuckDuckGo uses class="result__a" for links
+  const linkRegex = /<a[^>]+class="result__a"[^>]+href="([^"]+)"[^>]*>([^<]+)<\/a>/gi
+  const snippetRegex = /<a[^>]+class="result__snippet"[^>]*>([^<]*(?:<[^>]+>[^<]*)*)<\/a>/gi
+
+  let linkMatch
+  const links: { url: string; title: string }[] = []
+
+  while ((linkMatch = linkRegex.exec(html)) !== null && links.length < limit * 2) {
+    let url = linkMatch[1]
+    const title = linkMatch[2].trim()
+
+    // DuckDuckGo wraps URLs - extract the actual URL
+    if (url.includes('uddg=')) {
+      const match = url.match(/uddg=([^&]+)/)
+      if (match) {
+        url = decodeURIComponent(match[1])
+      }
+    }
+
+    // Only include results from recipe sites
+    if (RECIPE_SITES.some(site => url.includes(site))) {
+      links.push({ url, title })
+    }
+  }
+
+  // Get snippets
+  const snippets: string[] = []
+  let snippetMatch
+  while ((snippetMatch = snippetRegex.exec(html)) !== null) {
+    snippets.push(snippetMatch[1].replace(/<[^>]+>/g, '').trim())
+  }
+
+  // Combine links with snippets
+  for (let i = 0; i < Math.min(links.length, limit); i++) {
+    const { url, title } = links[i]
+
+    // Extract source domain
+    let source = 'web'
+    try {
+      source = new URL(url).hostname.replace('www.', '')
+    } catch {
+      // Keep default
+    }
+
+    results.push({
+      title: cleanRecipeTitle(title),
+      url,
+      snippet: snippets[i] || '',
+      source,
+    })
+  }
+
+  return results
+}
+
+/**
  * Clean up recipe titles from search results
  */
 function cleanRecipeTitle(title: string): string {
-  // Remove common suffixes like "| Allrecipes", "- Food Network", etc.
   return title
     .replace(/\s*[\|\-–—]\s*(Allrecipes|Food Network|Bon Appétit|Epicurious|Serious Eats|Budget Bytes|Delish|Simply Recipes|Taste of Home|NYT Cooking).*$/i, '')
     .replace(/\s*Recipe\s*$/i, '')
+    .replace(/&amp;/g, '&')
+    .replace(/&#39;/g, "'")
     .trim()
 }
 
 /**
- * Build search queries based on context (perishables, preferences, user request)
+ * Build search queries based on context
  */
 export function buildSearchQueries(
   perishables: string[],
@@ -84,29 +145,24 @@ export function buildSearchQueries(
 ): string[] {
   const queries: string[] = []
 
-  // If user has specific request, prioritize that
   if (userPrompt) {
     queries.push(userPrompt)
   }
 
-  // Build queries from expiring perishables
   if (perishables.length > 0) {
-    // Combine first 2-3 perishables into a query
     const perishableQuery = perishables.slice(0, 3).join(' ')
     queries.push(`easy ${perishableQuery} dinner`)
   }
 
-  // Build queries from preferred tags
   if (preferredTags.length > 0) {
     const tagQuery = preferredTags.slice(0, 2).join(' ')
-    queries.push(`${tagQuery} dinner recipes`)
+    queries.push(`${tagQuery} dinner`)
   }
 
-  // Add some variety queries if we don't have enough
   if (queries.length < 2) {
     queries.push('easy weeknight dinner')
     queries.push('quick family dinner')
   }
 
-  return queries.slice(0, 3) // Max 3 queries to limit API calls
+  return queries.slice(0, 3)
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "familymealplanner",
       "version": "0.1.0",
       "dependencies": {
+        "@anthropic-ai/sdk": "^0.71.2",
         "@auth/prisma-adapter": "^2.11.1",
         "@prisma/client": "^5.22.0",
         "@radix-ui/react-avatar": "^1.1.11",
@@ -61,6 +62,26 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.71.2",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.71.2.tgz",
+      "integrity": "sha512-TGNDEUuEstk/DKu0/TflXAEt+p+p/WhTlFzEnoosvbaDU2LTjm42igSdlL0VijrKpWejtOKxX0b8A7uc+XiSAQ==",
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/@auth/core": {
@@ -323,6 +344,15 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
+      "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -6820,6 +6850,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -9029,6 +9072,12 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "license": "MIT"
+    },
     "node_modules/ts-api-utils": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.3.0.tgz",
@@ -9661,7 +9710,7 @@
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.4.tgz",
       "integrity": "sha512-Zw/uYiiyF6pUT1qmKbZziChgNPRu+ZRneAsMUDU6IwmXdWt5JwcUfy2bvLOCUtz5UniaN/Zx5aFttZYbYc7O/A==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "stop": "./scripts/stop.sh"
   },
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.71.2",
     "@auth/prisma-adapter": "^2.11.1",
     "@prisma/client": "^5.22.0",
     "@radix-ui/react-avatar": "^1.1.11",


### PR DESCRIPTION
## Summary
- Add AI meal planner that suggests dinners based on family preferences, expiring perishables, and user requests
- Search web for new recipe ideas when the recipe library needs variety
- Switch recipe search from Google to DuckDuckGo for reliability
- Add weeknight rule: prefer quick meals (under 30-40 min) Monday-Thursday
- Prevent same recipe from being suggested twice in one week
- Remove confidence badge from suggestion cards for cleaner UI

## Test plan
- [ ] Generate AI meal plan for a week with existing recipes
- [ ] Verify weeknight meals are quick/simple, weekend allows complex recipes
- [ ] Confirm no duplicate recipes appear within the same week
- [ ] Test web recipe search and import flow
- [ ] Verify kid-downvoted recipes are excluded from suggestions

Fixes #10 