### PR TITLE
Restore image fetching for web recipe suggestions

### DIFF
--- a/app/api/ai-planner/generate/route.ts
+++ b/app/api/ai-planner/generate/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server'
 import Anthropic from '@anthropic-ai/sdk'
 import { getAuth } from '@/lib/api-auth'
 import { SYSTEM_PROMPT, buildUserPrompt, parseAIResponse } from '@/lib/ai-planner/prompt'
+import { fetchRecipeImage } from '@/lib/ai-planner/fetch-recipe-image'
 import type { GenerateRequest, GenerateResponse, AISuggestion } from '@/lib/ai-planner/types'
 
 const MAX_RETRIES = 1
@@ -145,14 +146,27 @@ export async function POST(request: Request) {
           return true
         })
 
-        // Enrich suggestions with image URLs (only for local recipes)
+        // Enrich suggestions with image URLs
         const recipeImageMap = new Map(
           availableRecipes.map((r) => [r.id, r.imageUrl])
         )
+
+        // Fetch images for web recipes in parallel
+        const webRecipes = suggestions.filter((s) => s.isWebRecipe)
+        const webImageResults = await Promise.all(
+          webRecipes.map(async (s) => ({
+            recipeId: s.recipeId,
+            imageUrl: await fetchRecipeImage(s.recipeId),
+          }))
+        )
+        const webImageMap = new Map(
+          webImageResults.map((r) => [r.recipeId, r.imageUrl])
+        )
+
         suggestions = suggestions.map((s) => ({
           ...s,
           imageUrl: s.isWebRecipe
-            ? null // Web recipe images will be fetched during import
+            ? webImageMap.get(s.recipeId) || null
             : recipeImageMap.get(s.recipeId) || null,
         }))
 

--- a/lib/ai-planner/fetch-recipe-image.ts
+++ b/lib/ai-planner/fetch-recipe-image.ts
@@ -1,0 +1,64 @@
+/**
+ * Fetch the image URL from a recipe page
+ * Looks for og:image, twitter:image, or schema.org image
+ */
+export async function fetchRecipeImage(url: string): Promise<string | null> {
+  try {
+    const response = await fetch(url, {
+      headers: {
+        'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+      },
+      signal: AbortSignal.timeout(5000),
+    })
+
+    if (!response.ok) {
+      return null
+    }
+
+    const html = await response.text()
+
+    // Try og:image first (most common)
+    const ogPatterns = [
+      /<meta\s+property=["']og:image["']\s+content=["']([^"']+)["']/i,
+      /<meta\s+content=["']([^"']+)["']\s+property=["']og:image["']/i,
+      /<meta[^>]+property=["']og:image["'][^>]+content=["']([^"']+)["']/i,
+    ]
+
+    for (const pattern of ogPatterns) {
+      const match = html.match(pattern)
+      if (match) {
+        return match[1]
+      }
+    }
+
+    // Try twitter:image
+    const twitterPatterns = [
+      /<meta[^>]+name=["']twitter:image["'][^>]+content=["']([^"']+)["']/i,
+      /<meta[^>]+content=["']([^"']+)["'][^>]+name=["']twitter:image["']/i,
+    ]
+
+    for (const pattern of twitterPatterns) {
+      const match = html.match(pattern)
+      if (match) {
+        return match[1]
+      }
+    }
+
+    // Try schema.org Recipe image
+    const schemaPatterns = [
+      /"image"\s*:\s*"([^"]+)"/i,
+      /"image"\s*:\s*\[\s*"([^"]+)"/i,
+    ]
+
+    for (const pattern of schemaPatterns) {
+      const match = html.match(pattern)
+      if (match) {
+        return match[1]
+      }
+    }
+
+    return null
+  } catch {
+    return null
+  }
+}


### PR DESCRIPTION
## Summary

Follow-up to #17 - restores image fetching for web recipe suggestions so images display in the suggestion cards before import.

## Changes

- Add `lib/ai-planner/fetch-recipe-image.ts` - fetches og:image/twitter:image from recipe URLs
- Update generate route to fetch images for web recipes in parallel

## Why

When we removed the Brave Search integration, we also lost the image enrichment step. This restores that functionality using the same `fetchRecipeImage()` helper.

## Test plan

- [ ] Verify web recipe suggestions show images in the AI planner modal
- [ ] Verify image fetching doesn't block/slow down suggestion generation significantly