### PR TITLE
Simplify perishables UX with bulk add and photo identification

### DIFF
--- a/app/api/perishables/parse/route.ts
+++ b/app/api/perishables/parse/route.ts
@@ -4,7 +4,7 @@ import { auth } from '@/lib/auth'
 
 const MODEL = 'claude-haiku-4-5-20251001'
 
-const SYSTEM_PROMPT = `You are a helpful assistant that parses free-form text about perishable food items into structured data.
+const TEXT_SYSTEM_PROMPT = `You are a helpful assistant that parses free-form text about perishable food items into structured data.
 
 Given a list of perishable items (one per line or comma-separated), extract:
 - name: The item name (required)
@@ -28,6 +28,25 @@ Example output:
   { "name": "Ground Beef", "quantity": 2, "unit": "lbs" }
 ]`
 
+const IMAGE_SYSTEM_PROMPT = `You are a helpful assistant that identifies perishable food items from photos.
+
+Look at the photo and identify all visible perishable food items. For each item, extract:
+- name: The item name (required) - use common grocery names
+- quantity: Estimated count or amount if you can tell (optional)
+- unit: Unit of measurement if applicable (optional) - use standard units like "lbs", "oz", "count", "dozen", "cups", etc.
+- expirationDate: ISO date string if you can read a date label (optional)
+- notes: Any relevant observations like "opened", "half used", "looks wilty" (optional)
+
+Be practical - list items you can reasonably identify. Don't guess at items you can't see clearly.
+
+Respond ONLY with a JSON array of objects. No other text.
+Example output:
+[
+  { "name": "Milk", "quantity": 1, "notes": "gallon jug" },
+  { "name": "Eggs", "quantity": 1, "unit": "dozen" },
+  { "name": "Spinach", "notes": "bag, looks fresh" }
+]`
+
 export interface ParsedPerishable {
   name: string
   quantity?: number
@@ -35,6 +54,8 @@ export interface ParsedPerishable {
   expirationDate?: string
   notes?: string
 }
+
+const MAX_IMAGE_SIZE = 5 * 1024 * 1024 // 5MB
 
 export async function POST(request: Request) {
   try {
@@ -50,31 +71,65 @@ export async function POST(request: Request) {
       )
     }
 
-    const { text } = await request.json()
+    const body = await request.json()
+    const { text, image, mediaType } = body
 
-    if (!text || typeof text !== 'string' || text.trim().length === 0) {
+    const hasText = text && typeof text === 'string' && text.trim().length > 0
+    const hasImage = image && typeof image === 'string' && mediaType
+
+    if (!hasText && !hasImage) {
       return NextResponse.json(
-        { error: 'Text is required' },
+        { error: 'Either text or image is required' },
         { status: 400 }
       )
     }
 
+    // Validate image size (base64 is ~33% larger than binary)
+    if (hasImage) {
+      const estimatedSize = (image.length * 3) / 4
+      if (estimatedSize > MAX_IMAGE_SIZE) {
+        return NextResponse.json(
+          { error: 'Image too large. Please use a smaller photo (max 5MB).' },
+          { status: 400 }
+        )
+      }
+    }
+
     const anthropic = new Anthropic()
-
     const today = new Date().toISOString().split('T')[0]
-    const userPrompt = `Today's date is ${today}.
 
-Parse these perishable items:
-${text.trim()}`
+    let content: Anthropic.MessageCreateParams['messages'][0]['content']
+    let systemPrompt: string
+
+    if (hasImage) {
+      systemPrompt = IMAGE_SYSTEM_PROMPT
+      content = [
+        {
+          type: 'image',
+          source: {
+            type: 'base64',
+            media_type: mediaType as 'image/jpeg' | 'image/png' | 'image/gif' | 'image/webp',
+            data: image,
+          },
+        },
+        {
+          type: 'text',
+          text: `Today's date is ${today}. Identify all perishable food items in this photo.`,
+        },
+      ]
+    } else {
+      systemPrompt = TEXT_SYSTEM_PROMPT
+      content = `Today's date is ${today}.\n\nParse these perishable items:\n${text.trim()}`
+    }
 
     const response = await anthropic.messages.create({
       model: MODEL,
       max_tokens: 1024,
-      system: SYSTEM_PROMPT,
+      system: systemPrompt,
       messages: [
         {
           role: 'user',
-          content: userPrompt,
+          content,
         },
       ],
     })

--- a/app/api/perishables/parse/route.ts
+++ b/app/api/perishables/parse/route.ts
@@ -1,0 +1,145 @@
+import { NextResponse } from 'next/server'
+import Anthropic from '@anthropic-ai/sdk'
+import { auth } from '@/lib/auth'
+
+const MODEL = 'claude-haiku-4-5-20251001'
+
+const SYSTEM_PROMPT = `You are a helpful assistant that parses free-form text about perishable food items into structured data.
+
+Given a list of perishable items (one per line or comma-separated), extract:
+- name: The item name (required)
+- quantity: Numeric quantity if mentioned (optional)
+- unit: Unit of measurement if mentioned (optional) - use standard units like "lbs", "oz", "count", "dozen", "cups", etc.
+- expirationDate: ISO date string if mentioned (optional) - interpret relative dates like "tomorrow", "in 3 days", "next week" based on today's date
+
+Handle natural language gracefully:
+- "3 apples" → { name: "Apples", quantity: 3 }
+- "half a lemon" → { name: "Lemon", quantity: 0.5 }
+- "milk expires tomorrow" → { name: "Milk", expirationDate: "<tomorrow's date>" }
+- "2 lbs ground beef" → { name: "Ground Beef", quantity: 2, unit: "lbs" }
+- "leftover chicken" → { name: "Chicken", notes: "leftover" }
+- "spinach (wilty)" → { name: "Spinach", notes: "wilty" }
+
+Respond ONLY with a JSON array of objects. No other text.
+Example output:
+[
+  { "name": "Apples", "quantity": 3 },
+  { "name": "Milk", "expirationDate": "2024-02-01" },
+  { "name": "Ground Beef", "quantity": 2, "unit": "lbs" }
+]`
+
+export interface ParsedPerishable {
+  name: string
+  quantity?: number
+  unit?: string
+  expirationDate?: string
+  notes?: string
+}
+
+export async function POST(request: Request) {
+  try {
+    const session = await auth()
+    if (!session?.user?.householdId) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    if (!process.env.ANTHROPIC_API_KEY) {
+      return NextResponse.json(
+        { error: 'AI features not configured' },
+        { status: 503 }
+      )
+    }
+
+    const { text } = await request.json()
+
+    if (!text || typeof text !== 'string' || text.trim().length === 0) {
+      return NextResponse.json(
+        { error: 'Text is required' },
+        { status: 400 }
+      )
+    }
+
+    const anthropic = new Anthropic()
+
+    const today = new Date().toISOString().split('T')[0]
+    const userPrompt = `Today's date is ${today}.
+
+Parse these perishable items:
+${text.trim()}`
+
+    const response = await anthropic.messages.create({
+      model: MODEL,
+      max_tokens: 1024,
+      system: SYSTEM_PROMPT,
+      messages: [
+        {
+          role: 'user',
+          content: userPrompt,
+        },
+      ],
+    })
+
+    const textBlock = response.content.find((c) => c.type === 'text')
+    if (!textBlock || textBlock.type !== 'text') {
+      throw new Error('No text response from AI')
+    }
+
+    // Parse the JSON response
+    let parsed: ParsedPerishable[]
+    try {
+      // Extract JSON from the response (handle potential markdown code blocks)
+      let jsonText = textBlock.text.trim()
+      if (jsonText.startsWith('```')) {
+        jsonText = jsonText.replace(/^```(?:json)?\n?/, '').replace(/\n?```$/, '')
+      }
+      parsed = JSON.parse(jsonText)
+    } catch {
+      console.error('Failed to parse AI response:', textBlock.text)
+      return NextResponse.json(
+        { error: 'Failed to parse items. Please try again.' },
+        { status: 422 }
+      )
+    }
+
+    // Validate and clean up the parsed items
+    const items = parsed
+      .filter((item) => item && typeof item.name === 'string' && item.name.trim())
+      .map((item) => ({
+        name: item.name.trim(),
+        quantity: typeof item.quantity === 'number' ? item.quantity : undefined,
+        unit: typeof item.unit === 'string' ? item.unit : undefined,
+        expirationDate: typeof item.expirationDate === 'string' ? item.expirationDate : undefined,
+        notes: typeof item.notes === 'string' ? item.notes : undefined,
+      }))
+
+    return NextResponse.json({
+      items,
+      usage: {
+        inputTokens: response.usage.input_tokens,
+        outputTokens: response.usage.output_tokens,
+      },
+    })
+  } catch (error) {
+    console.error('Error parsing perishables:', error)
+
+    if (error instanceof Anthropic.APIError) {
+      if (error.status === 401) {
+        return NextResponse.json(
+          { error: 'Invalid API key configuration' },
+          { status: 503 }
+        )
+      }
+      if (error.status === 429) {
+        return NextResponse.json(
+          { error: 'Rate limit exceeded. Please try again.' },
+          { status: 429 }
+        )
+      }
+    }
+
+    return NextResponse.json(
+      { error: 'Failed to parse items' },
+      { status: 500 }
+    )
+  }
+}

--- a/components/perishables-list.tsx
+++ b/components/perishables-list.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { useState, useRef } from 'react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
@@ -22,7 +22,7 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog'
 import { toast } from 'sonner'
-import { Trash2, ChevronDown, ChevronUp, Plus, Loader2, Sparkles, X } from 'lucide-react'
+import { Trash2, ChevronDown, ChevronUp, Plus, Loader2, Sparkles, X, Camera } from 'lucide-react'
 
 interface Perishable {
   id: string
@@ -123,6 +123,8 @@ export function PerishablesList({ initialPerishables }: PerishablesListProps) {
   const [isParsing, setIsParsing] = useState(false)
   const [parsedItems, setParsedItems] = useState<ParsedPerishable[] | null>(null)
   const [isAddingBulk, setIsAddingBulk] = useState(false)
+  const [photoPreview, setPhotoPreview] = useState<string | null>(null)
+  const fileInputRef = useRef<HTMLInputElement>(null)
 
   const handleAdd = async (quickAddName?: string) => {
     const name = quickAddName || newName.trim()
@@ -324,6 +326,65 @@ export function PerishablesList({ initialPerishables }: PerishablesListProps) {
     }
   }
 
+  const handlePhotoSelect = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0]
+    if (!file) return
+
+    // Reset the input so the same file can be re-selected
+    e.target.value = ''
+
+    if (!file.type.startsWith('image/')) {
+      toast.error('Please select an image file')
+      return
+    }
+
+    if (file.size > 5 * 1024 * 1024) {
+      toast.error('Image too large. Please use a smaller photo (max 5MB).')
+      return
+    }
+
+    // Read as base64
+    const reader = new FileReader()
+    reader.onload = async () => {
+      const dataUrl = reader.result as string
+      // dataUrl format: "data:image/jpeg;base64,/9j/4AAQ..."
+      const base64 = dataUrl.split(',')[1]
+      const mediaType = dataUrl.split(';')[0].split(':')[1]
+
+      setPhotoPreview(dataUrl)
+      setBulkAddOpen(true)
+      setIsParsing(true)
+
+      try {
+        const response = await fetch('/api/perishables/parse', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ image: base64, mediaType }),
+        })
+
+        if (!response.ok) {
+          const error = await response.json()
+          throw new Error(error.error || 'Failed to identify items')
+        }
+
+        const { items } = await response.json()
+
+        const existingNames = new Set(perishables.map((p) => p.name.toLowerCase()))
+        const itemsWithSelection = items.map((item: ParsedPerishable) => ({
+          ...item,
+          selected: !existingNames.has(item.name.toLowerCase()),
+        }))
+
+        setParsedItems(itemsWithSelection)
+      } catch (error) {
+        toast.error(error instanceof Error ? error.message : 'Failed to identify items')
+      } finally {
+        setIsParsing(false)
+      }
+    }
+    reader.readAsDataURL(file)
+  }
+
   const toggleParsedItem = (index: number) => {
     if (!parsedItems) return
     setParsedItems(
@@ -394,6 +455,7 @@ export function PerishablesList({ initialPerishables }: PerishablesListProps) {
     setBulkAddOpen(false)
     setBulkText('')
     setParsedItems(null)
+    setPhotoPreview(null)
 
     if (addedCount > 0) {
       toast.success(`Added ${addedCount} item${addedCount !== 1 ? 's' : ''}${skippedCount > 0 ? ` (${skippedCount} skipped)` : ''}`)
@@ -406,6 +468,7 @@ export function PerishablesList({ initialPerishables }: PerishablesListProps) {
     setBulkAddOpen(false)
     setBulkText('')
     setParsedItems(null)
+    setPhotoPreview(null)
   }
 
   const availableSuggestions = COMMON_PERISHABLES.filter(
@@ -605,6 +668,23 @@ export function PerishablesList({ initialPerishables }: PerishablesListProps) {
               <Sparkles className="h-4 w-4 mr-1" />
               Add multiple items
             </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => fileInputRef.current?.click()}
+              className="text-muted-foreground"
+            >
+              <Camera className="h-4 w-4 mr-1" />
+              Snap a photo
+            </Button>
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept="image/*"
+              capture="environment"
+              onChange={handlePhotoSelect}
+              className="hidden"
+            />
           </div>
 
           {availableSuggestions.length > 0 && (
@@ -686,13 +766,31 @@ export function PerishablesList({ initialPerishables }: PerishablesListProps) {
       <Dialog open={bulkAddOpen} onOpenChange={(open) => !open && closeBulkAdd()}>
         <DialogContent className="sm:max-w-md">
           <DialogHeader>
-            <DialogTitle>Add Multiple Items</DialogTitle>
+            <DialogTitle>
+              {photoPreview ? 'Photo Results' : 'Add Multiple Items'}
+            </DialogTitle>
             <DialogDescription>
-              Type or paste your items naturally. We&apos;ll figure out the details.
+              {photoPreview
+                ? 'We identified these items from your photo.'
+                : 'Type or paste your items naturally. We\'ll figure out the details.'}
             </DialogDescription>
           </DialogHeader>
 
-          {!parsedItems ? (
+          {isParsing && !parsedItems ? (
+            <div className="flex flex-col items-center gap-4 py-8">
+              {photoPreview && (
+                <img
+                  src={photoPreview}
+                  alt="Uploaded photo"
+                  className="max-h-[150px] rounded-lg object-cover"
+                />
+              )}
+              <div className="flex items-center gap-2 text-muted-foreground">
+                <Loader2 className="h-5 w-5 animate-spin" />
+                {photoPreview ? 'Identifying items...' : 'Parsing...'}
+              </div>
+            </div>
+          ) : !parsedItems ? (
             <>
               <Textarea
                 placeholder={`Example:
@@ -714,17 +812,8 @@ spinach (a bit wilty)`}
                   onClick={handleParse}
                   disabled={!bulkText.trim() || isParsing}
                 >
-                  {isParsing ? (
-                    <>
-                      <Loader2 className="h-4 w-4 mr-2 animate-spin" />
-                      Parsing...
-                    </>
-                  ) : (
-                    <>
-                      <Sparkles className="h-4 w-4 mr-2" />
-                      Parse Items
-                    </>
-                  )}
+                  <Sparkles className="h-4 w-4 mr-2" />
+                  Parse Items
                 </Button>
               </DialogFooter>
             </>
@@ -785,9 +874,9 @@ spinach (a bit wilty)`}
               <DialogFooter>
                 <Button
                   variant="outline"
-                  onClick={() => setParsedItems(null)}
+                  onClick={() => photoPreview ? closeBulkAdd() : setParsedItems(null)}
                 >
-                  Back
+                  {photoPreview ? 'Cancel' : 'Back'}
                 </Button>
                 <Button
                   onClick={handleAddBulk}

--- a/components/perishables-list.tsx
+++ b/components/perishables-list.tsx
@@ -5,6 +5,7 @@ import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
+import { Textarea } from '@/components/ui/textarea'
 import {
   Select,
   SelectContent,
@@ -12,8 +13,16 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
 import { toast } from 'sonner'
-import { Trash2 } from 'lucide-react'
+import { Trash2, ChevronDown, ChevronUp, Plus, Loader2, Sparkles, X } from 'lucide-react'
 
 interface Perishable {
   id: string
@@ -22,6 +31,15 @@ interface Perishable {
   quantity: string | null
   unit: string | null
   expirationDate: string | null
+}
+
+interface ParsedPerishable {
+  name: string
+  quantity?: number
+  unit?: string
+  expirationDate?: string
+  notes?: string
+  selected?: boolean
 }
 
 interface PerishablesListProps {
@@ -86,13 +104,30 @@ export function PerishablesList({ initialPerishables }: PerishablesListProps) {
   const [newQuantity, setNewQuantity] = useState('')
   const [newUnit, setNewUnit] = useState('')
   const [newExpiration, setNewExpiration] = useState('')
+  const [showAddDetails, setShowAddDetails] = useState(false)
   const [isAdding, setIsAdding] = useState(false)
+  const [expandedItemId, setExpandedItemId] = useState<string | null>(null)
+  const [editingItem, setEditingItem] = useState<{
+    quantity: string
+    unit: string
+    expirationDate: string
+  } | null>(null)
+
+  // Clear all state
+  const [clearAllOpen, setClearAllOpen] = useState(false)
+  const [isClearing, setIsClearing] = useState(false)
+
+  // Bulk add state
+  const [bulkAddOpen, setBulkAddOpen] = useState(false)
+  const [bulkText, setBulkText] = useState('')
+  const [isParsing, setIsParsing] = useState(false)
+  const [parsedItems, setParsedItems] = useState<ParsedPerishable[] | null>(null)
+  const [isAddingBulk, setIsAddingBulk] = useState(false)
 
   const handleAdd = async (quickAddName?: string) => {
     const name = quickAddName || newName.trim()
     if (!name) return
 
-    // Check if already exists
     if (perishables.some((p) => p.name.toLowerCase() === name.toLowerCase())) {
       toast.error('This item already exists')
       return
@@ -106,7 +141,7 @@ export function PerishablesList({ initialPerishables }: PerishablesListProps) {
         body: JSON.stringify({
           name,
           quantity: quickAddName ? null : (newQuantity || null),
-          unit: quickAddName ? null : (newUnit || null),
+          unit: quickAddName ? null : (newUnit && newUnit !== 'none' ? newUnit : null),
           expirationDate: quickAddName ? null : (newExpiration || null),
         }),
       })
@@ -117,7 +152,6 @@ export function PerishablesList({ initialPerishables }: PerishablesListProps) {
       }
 
       const perishable = await response.json()
-      // Serialize the response for consistency
       const serialized: Perishable = {
         ...perishable,
         quantity: perishable.quantity ? perishable.quantity.toString() : null,
@@ -128,7 +162,6 @@ export function PerishablesList({ initialPerishables }: PerishablesListProps) {
 
       setPerishables((prev) => {
         const updated = [...prev, serialized]
-        // Sort by expiration date (nulls last), then by name
         return updated.sort((a, b) => {
           if (a.expirationDate && b.expirationDate) {
             return a.expirationDate.localeCompare(b.expirationDate)
@@ -139,11 +172,11 @@ export function PerishablesList({ initialPerishables }: PerishablesListProps) {
         })
       })
 
-      // Clear form
       setNewName('')
       setNewQuantity('')
       setNewUnit('')
       setNewExpiration('')
+      setShowAddDetails(false)
       toast.success('Item added')
     } catch (error) {
       toast.error(error instanceof Error ? error.message : 'Failed to add item')
@@ -163,17 +196,222 @@ export function PerishablesList({ initialPerishables }: PerishablesListProps) {
       }
 
       setPerishables((prev) => prev.filter((p) => p.id !== id))
+      setExpandedItemId(null)
       toast.success('Item removed')
     } catch {
       toast.error('Failed to remove item')
     }
   }
 
+  const handleClearAll = async () => {
+    setIsClearing(true)
+    let deletedCount = 0
+    let failedCount = 0
+
+    for (const item of perishables) {
+      try {
+        const response = await fetch(`/api/perishables/${item.id}`, {
+          method: 'DELETE',
+        })
+        if (response.ok) {
+          deletedCount++
+        } else {
+          failedCount++
+        }
+      } catch {
+        failedCount++
+      }
+    }
+
+    setPerishables([])
+    setExpandedItemId(null)
+    setIsClearing(false)
+    setClearAllOpen(false)
+
+    if (failedCount === 0) {
+      toast.success(`Cleared ${deletedCount} items`)
+    } else {
+      toast.success(`Cleared ${deletedCount} items (${failedCount} failed)`)
+    }
+  }
+
+  const handleUpdate = async (id: string) => {
+    if (!editingItem) return
+
+    try {
+      const response = await fetch(`/api/perishables/${id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          quantity: editingItem.quantity || null,
+          unit: editingItem.unit && editingItem.unit !== 'none' ? editingItem.unit : null,
+          expirationDate: editingItem.expirationDate || null,
+        }),
+      })
+
+      if (!response.ok) {
+        throw new Error('Failed to update item')
+      }
+
+      const updated = await response.json()
+      setPerishables((prev) =>
+        prev.map((p) =>
+          p.id === id
+            ? {
+                ...p,
+                quantity: updated.quantity ? updated.quantity.toString() : null,
+                unit: updated.unit,
+                expirationDate: updated.expirationDate
+                  ? new Date(updated.expirationDate).toISOString().split('T')[0]
+                  : null,
+              }
+            : p
+        )
+      )
+      setExpandedItemId(null)
+      setEditingItem(null)
+      toast.success('Item updated')
+    } catch {
+      toast.error('Failed to update item')
+    }
+  }
+
+  const toggleExpand = (item: Perishable) => {
+    if (expandedItemId === item.id) {
+      setExpandedItemId(null)
+      setEditingItem(null)
+    } else {
+      setExpandedItemId(item.id)
+      setEditingItem({
+        quantity: item.quantity || '',
+        unit: item.unit || '',
+        expirationDate: item.expirationDate || '',
+      })
+    }
+  }
+
+  // Bulk add handlers
+  const handleParse = async () => {
+    if (!bulkText.trim()) return
+
+    setIsParsing(true)
+    try {
+      const response = await fetch('/api/perishables/parse', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ text: bulkText }),
+      })
+
+      if (!response.ok) {
+        const error = await response.json()
+        throw new Error(error.error || 'Failed to parse items')
+      }
+
+      const { items } = await response.json()
+
+      // Mark items that already exist
+      const existingNames = new Set(perishables.map((p) => p.name.toLowerCase()))
+      const itemsWithSelection = items.map((item: ParsedPerishable) => ({
+        ...item,
+        selected: !existingNames.has(item.name.toLowerCase()),
+      }))
+
+      setParsedItems(itemsWithSelection)
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Failed to parse items')
+    } finally {
+      setIsParsing(false)
+    }
+  }
+
+  const toggleParsedItem = (index: number) => {
+    if (!parsedItems) return
+    setParsedItems(
+      parsedItems.map((item, i) =>
+        i === index ? { ...item, selected: !item.selected } : item
+      )
+    )
+  }
+
+  const handleAddBulk = async () => {
+    if (!parsedItems) return
+
+    const itemsToAdd = parsedItems.filter((item) => item.selected)
+    if (itemsToAdd.length === 0) {
+      toast.error('No items selected')
+      return
+    }
+
+    setIsAddingBulk(true)
+    let addedCount = 0
+    let skippedCount = 0
+
+    for (const item of itemsToAdd) {
+      try {
+        const response = await fetch('/api/perishables', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            name: item.name,
+            quantity: item.quantity || null,
+            unit: item.unit || null,
+            expirationDate: item.expirationDate || null,
+          }),
+        })
+
+        if (response.ok) {
+          const perishable = await response.json()
+          const serialized: Perishable = {
+            ...perishable,
+            quantity: perishable.quantity ? perishable.quantity.toString() : null,
+            expirationDate: perishable.expirationDate
+              ? new Date(perishable.expirationDate).toISOString().split('T')[0]
+              : null,
+          }
+          setPerishables((prev) => [...prev, serialized])
+          addedCount++
+        } else {
+          skippedCount++
+        }
+      } catch {
+        skippedCount++
+      }
+    }
+
+    // Sort after all additions
+    setPerishables((prev) =>
+      [...prev].sort((a, b) => {
+        if (a.expirationDate && b.expirationDate) {
+          return a.expirationDate.localeCompare(b.expirationDate)
+        }
+        if (a.expirationDate) return -1
+        if (b.expirationDate) return 1
+        return a.displayName.localeCompare(b.displayName)
+      })
+    )
+
+    setIsAddingBulk(false)
+    setBulkAddOpen(false)
+    setBulkText('')
+    setParsedItems(null)
+
+    if (addedCount > 0) {
+      toast.success(`Added ${addedCount} item${addedCount !== 1 ? 's' : ''}${skippedCount > 0 ? ` (${skippedCount} skipped)` : ''}`)
+    } else {
+      toast.error('No items were added')
+    }
+  }
+
+  const closeBulkAdd = () => {
+    setBulkAddOpen(false)
+    setBulkText('')
+    setParsedItems(null)
+  }
+
   const availableSuggestions = COMMON_PERISHABLES.filter(
     (name) => !perishables.some((p) => p.name.toLowerCase() === name.toLowerCase())
   )
 
-  // Separate items by expiration status
   const expiredItems = perishables.filter((p) => {
     if (!p.expirationDate) return false
     return new Date(p.expirationDate) < new Date(new Date().toDateString())
@@ -183,36 +421,62 @@ export function PerishablesList({ initialPerishables }: PerishablesListProps) {
     return new Date(p.expirationDate) >= new Date(new Date().toDateString())
   })
 
-  return (
-    <div className="space-y-6">
-      <Card>
-        <CardHeader>
-          <CardTitle className="text-lg">Add Item</CardTitle>
-        </CardHeader>
-        <CardContent className="space-y-4">
-          <div className="grid gap-4">
-            <Input
-              placeholder="Item name (required)"
-              value={newName}
-              onChange={(e) => setNewName(e.target.value)}
-              onKeyDown={(e) => {
-                if (e.key === 'Enter' && newName.trim()) handleAdd()
-              }}
-            />
+  const renderItem = (item: Perishable, isExpired: boolean = false) => {
+    const status = getExpirationStatus(item.expirationDate)
+    const qty = formatQuantity(item.quantity, item.unit)
+    const isExpanded = expandedItemId === item.id
+
+    return (
+      <div
+        key={item.id}
+        className={`rounded-lg ${isExpired ? 'bg-destructive/10' : 'hover:bg-muted/50'}`}
+      >
+        <div
+          className="flex items-center justify-between p-2 cursor-pointer"
+          onClick={() => toggleExpand(item)}
+        >
+          <div className="flex items-center gap-2 flex-wrap flex-1">
+            <span className="font-medium">{item.displayName}</span>
+            {qty && (
+              <span className="text-sm text-muted-foreground">({qty})</span>
+            )}
+            <Badge variant={status.variant} className={status.className}>
+              {status.label}
+            </Badge>
+          </div>
+          <div className="flex items-center gap-1">
+            {isExpanded ? (
+              <ChevronUp className="h-4 w-4 text-muted-foreground" />
+            ) : (
+              <ChevronDown className="h-4 w-4 text-muted-foreground" />
+            )}
+          </div>
+        </div>
+
+        {isExpanded && editingItem && (
+          <div className="px-2 pb-2 space-y-2 border-t pt-2 mx-2">
             <div className="grid grid-cols-2 gap-2">
               <Input
                 type="number"
                 placeholder="Quantity"
-                value={newQuantity}
-                onChange={(e) => setNewQuantity(e.target.value)}
+                value={editingItem.quantity}
+                onChange={(e) =>
+                  setEditingItem({ ...editingItem, quantity: e.target.value })
+                }
                 min="0"
                 step="0.1"
               />
-              <Select value={newUnit || undefined} onValueChange={setNewUnit}>
+              <Select
+                value={editingItem.unit || undefined}
+                onValueChange={(value) =>
+                  setEditingItem({ ...editingItem, unit: value })
+                }
+              >
                 <SelectTrigger>
-                  <SelectValue placeholder="Unit (optional)" />
+                  <SelectValue placeholder="Unit" />
                 </SelectTrigger>
                 <SelectContent>
+                  <SelectItem value="none">No unit</SelectItem>
                   {UNITS.map((unit) => (
                     <SelectItem key={unit} value={unit}>
                       {unit}
@@ -221,20 +485,126 @@ export function PerishablesList({ initialPerishables }: PerishablesListProps) {
                 </SelectContent>
               </Select>
             </div>
-            <div className="flex gap-2">
+            <Input
+              type="date"
+              value={editingItem.expirationDate}
+              onChange={(e) =>
+                setEditingItem({ ...editingItem, expirationDate: e.target.value })
+              }
+              placeholder="Expiration date"
+            />
+            <div className="flex gap-2 justify-end">
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={(e) => {
+                  e.stopPropagation()
+                  handleDelete(item.id)
+                }}
+                className="text-destructive hover:text-destructive"
+              >
+                <Trash2 className="h-4 w-4 mr-1" />
+                Remove
+              </Button>
+              <Button
+                size="sm"
+                onClick={(e) => {
+                  e.stopPropagation()
+                  handleUpdate(item.id)
+                }}
+              >
+                Save
+              </Button>
+            </div>
+          </div>
+        )}
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-6">
+      <Card>
+        <CardHeader className="pb-3">
+          <CardTitle className="text-lg">Add Item</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="flex gap-2">
+            <Input
+              placeholder="What's in your fridge?"
+              value={newName}
+              onChange={(e) => setNewName(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' && newName.trim()) handleAdd()
+              }}
+              className="flex-1"
+            />
+            <Button
+              onClick={() => handleAdd()}
+              disabled={!newName.trim() || isAdding}
+            >
+              <Plus className="h-4 w-4 mr-1" />
+              Add
+            </Button>
+          </div>
+
+          <button
+            type="button"
+            onClick={() => setShowAddDetails(!showAddDetails)}
+            className="flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground transition-colors"
+          >
+            {showAddDetails ? (
+              <ChevronUp className="h-4 w-4" />
+            ) : (
+              <ChevronDown className="h-4 w-4" />
+            )}
+            {showAddDetails ? 'Hide details' : 'Add details (qty, expiration)'}
+          </button>
+
+          {showAddDetails && (
+            <div className="space-y-2 pl-1 border-l-2 border-muted ml-1">
+              <div className="grid grid-cols-2 gap-2">
+                <Input
+                  type="number"
+                  placeholder="Quantity"
+                  value={newQuantity}
+                  onChange={(e) => setNewQuantity(e.target.value)}
+                  min="0"
+                  step="0.1"
+                />
+                <Select value={newUnit || undefined} onValueChange={setNewUnit}>
+                  <SelectTrigger>
+                    <SelectValue placeholder="Unit" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="none">No unit</SelectItem>
+                    {UNITS.map((unit) => (
+                      <SelectItem key={unit} value={unit}>
+                        {unit}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
               <Input
                 type="date"
                 value={newExpiration}
                 onChange={(e) => setNewExpiration(e.target.value)}
-                className="flex-1"
+                placeholder="Expiration date"
               />
-              <Button
-                onClick={() => handleAdd()}
-                disabled={!newName.trim() || isAdding}
-              >
-                Add
-              </Button>
             </div>
+          )}
+
+          <div className="flex items-center gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setBulkAddOpen(true)}
+              className="text-muted-foreground"
+            >
+              <Sparkles className="h-4 w-4 mr-1" />
+              Add multiple items
+            </Button>
           </div>
 
           {availableSuggestions.length > 0 && (
@@ -266,45 +636,29 @@ export function PerishablesList({ initialPerishables }: PerishablesListProps) {
             </CardTitle>
           </CardHeader>
           <CardContent>
-            <div className="space-y-2">
-              {expiredItems.map((item) => {
-                const status = getExpirationStatus(item.expirationDate)
-                const qty = formatQuantity(item.quantity, item.unit)
-                return (
-                  <div
-                    key={item.id}
-                    className="flex items-center justify-between p-2 rounded-lg bg-destructive/10"
-                  >
-                    <div className="flex items-center gap-2">
-                      <span className="font-medium">{item.displayName}</span>
-                      {qty && (
-                        <span className="text-sm text-muted-foreground">({qty})</span>
-                      )}
-                      <Badge variant={status.variant} className={status.className}>
-                        {status.label}
-                      </Badge>
-                    </div>
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      onClick={() => handleDelete(item.id)}
-                      className="h-8 w-8 text-destructive hover:text-destructive"
-                    >
-                      <Trash2 className="h-4 w-4" />
-                    </Button>
-                  </div>
-                )
-              })}
+            <div className="space-y-1">
+              {expiredItems.map((item) => renderItem(item, true))}
             </div>
           </CardContent>
         </Card>
       )}
 
       <Card>
-        <CardHeader>
+        <CardHeader className="flex flex-row items-center justify-between space-y-0">
           <CardTitle className="text-lg">
             Your Perishables ({activeItems.length})
           </CardTitle>
+          {perishables.length > 0 && (
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => setClearAllOpen(true)}
+              className="text-muted-foreground hover:text-destructive"
+            >
+              <Trash2 className="h-4 w-4 mr-1" />
+              Clear all
+            </Button>
+          )}
         </CardHeader>
         <CardContent>
           {activeItems.length === 0 ? (
@@ -312,35 +666,8 @@ export function PerishablesList({ initialPerishables }: PerishablesListProps) {
               No perishables tracked. Add items to get recipe suggestions that help you use them before they expire.
             </p>
           ) : (
-            <div className="space-y-2">
-              {activeItems.map((item) => {
-                const status = getExpirationStatus(item.expirationDate)
-                const qty = formatQuantity(item.quantity, item.unit)
-                return (
-                  <div
-                    key={item.id}
-                    className="flex items-center justify-between p-2 rounded-lg hover:bg-muted/50"
-                  >
-                    <div className="flex items-center gap-2 flex-wrap">
-                      <span className="font-medium">{item.displayName}</span>
-                      {qty && (
-                        <span className="text-sm text-muted-foreground">({qty})</span>
-                      )}
-                      <Badge variant={status.variant} className={status.className}>
-                        {status.label}
-                      </Badge>
-                    </div>
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      onClick={() => handleDelete(item.id)}
-                      className="h-8 w-8 text-muted-foreground hover:text-destructive"
-                    >
-                      <Trash2 className="h-4 w-4" />
-                    </Button>
-                  </div>
-                )
-              })}
+            <div className="space-y-1">
+              {activeItems.map((item) => renderItem(item))}
             </div>
           )}
         </CardContent>
@@ -349,12 +676,172 @@ export function PerishablesList({ initialPerishables }: PerishablesListProps) {
       <Card>
         <CardContent className="py-4">
           <p className="text-sm text-muted-foreground">
-            Perishables are items that may expire. When you get recipe suggestions,
-            recipes using these items will be prioritized—especially those using items
-            expiring soon.
+            Tap any item to edit quantity, unit, or expiration date.
+            Perishables expiring soon will be prioritized in recipe suggestions.
           </p>
         </CardContent>
       </Card>
+
+      {/* Bulk Add Dialog */}
+      <Dialog open={bulkAddOpen} onOpenChange={(open) => !open && closeBulkAdd()}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>Add Multiple Items</DialogTitle>
+            <DialogDescription>
+              Type or paste your items naturally. We&apos;ll figure out the details.
+            </DialogDescription>
+          </DialogHeader>
+
+          {!parsedItems ? (
+            <>
+              <Textarea
+                placeholder={`Example:
+3 apples
+milk expires tomorrow
+2 lbs ground beef
+leftover chicken
+half a lemon
+spinach (a bit wilty)`}
+                value={bulkText}
+                onChange={(e) => setBulkText(e.target.value)}
+                className="min-h-[150px]"
+              />
+              <DialogFooter>
+                <Button variant="outline" onClick={closeBulkAdd}>
+                  Cancel
+                </Button>
+                <Button
+                  onClick={handleParse}
+                  disabled={!bulkText.trim() || isParsing}
+                >
+                  {isParsing ? (
+                    <>
+                      <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                      Parsing...
+                    </>
+                  ) : (
+                    <>
+                      <Sparkles className="h-4 w-4 mr-2" />
+                      Parse Items
+                    </>
+                  )}
+                </Button>
+              </DialogFooter>
+            </>
+          ) : (
+            <>
+              <div className="space-y-2 max-h-[300px] overflow-y-auto">
+                {parsedItems.map((item, index) => {
+                  const exists = perishables.some(
+                    (p) => p.name.toLowerCase() === item.name.toLowerCase()
+                  )
+                  return (
+                    <div
+                      key={index}
+                      className={`flex items-center gap-2 p-2 rounded-lg border ${
+                        exists
+                          ? 'border-yellow-500/50 bg-yellow-500/10'
+                          : item.selected
+                          ? 'border-primary bg-primary/5'
+                          : 'border-muted'
+                      }`}
+                    >
+                      <input
+                        type="checkbox"
+                        checked={item.selected}
+                        onChange={() => toggleParsedItem(index)}
+                        className="h-4 w-4"
+                        disabled={exists}
+                      />
+                      <div className="flex-1">
+                        <div className="font-medium">{item.name}</div>
+                        <div className="text-sm text-muted-foreground">
+                          {[
+                            item.quantity && `${item.quantity}${item.unit ? ` ${item.unit}` : ''}`,
+                            item.expirationDate && `exp: ${item.expirationDate}`,
+                            item.notes && item.notes,
+                          ]
+                            .filter(Boolean)
+                            .join(' • ') || 'No details'}
+                        </div>
+                        {exists && (
+                          <div className="text-xs text-yellow-600">Already exists</div>
+                        )}
+                      </div>
+                      {!exists && item.selected && (
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          className="h-6 w-6"
+                          onClick={() => toggleParsedItem(index)}
+                        >
+                          <X className="h-4 w-4" />
+                        </Button>
+                      )}
+                    </div>
+                  )
+                })}
+              </div>
+              <DialogFooter>
+                <Button
+                  variant="outline"
+                  onClick={() => setParsedItems(null)}
+                >
+                  Back
+                </Button>
+                <Button
+                  onClick={handleAddBulk}
+                  disabled={isAddingBulk || !parsedItems.some((i) => i.selected)}
+                >
+                  {isAddingBulk ? (
+                    <>
+                      <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                      Adding...
+                    </>
+                  ) : (
+                    `Add ${parsedItems.filter((i) => i.selected).length} Items`
+                  )}
+                </Button>
+              </DialogFooter>
+            </>
+          )}
+        </DialogContent>
+      </Dialog>
+
+      {/* Clear All Confirmation Dialog */}
+      <Dialog open={clearAllOpen} onOpenChange={setClearAllOpen}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>Clear all perishables?</DialogTitle>
+            <DialogDescription>
+              This will remove all {perishables.length} items from your list. This action cannot be undone.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => setClearAllOpen(false)}
+              disabled={isClearing}
+            >
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={handleClearAll}
+              disabled={isClearing}
+            >
+              {isClearing ? (
+                <>
+                  <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                  Clearing...
+                </>
+              ) : (
+                'Clear all'
+              )}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   )
 }

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -32,10 +32,14 @@ else
 fi
 echo "✅ PostgreSQL is ready"
 
+# Set default database URLs for local dev if not already set
+export DATABASE_URL="${DATABASE_URL:-postgresql://familytable:familytable_dev@localhost:5434/familytable?schema=public}"
+export DIRECT_URL="${DIRECT_URL:-$DATABASE_URL}"
+
 # Run Prisma migrations
 echo ""
 echo "🔄 Syncing database schema..."
-npx prisma db push --skip-generate
+npx prisma db push
 
 # Generate Prisma client
 echo ""


### PR DESCRIPTION
## Summary

- **Simplified add form**: Default is now a single name input + Add button, with quantity/unit/expiration tucked behind an expandable "Add details" toggle
- **Inline editing**: Tap any existing item to expand and edit its details (quantity, unit, expiration) in place
- **AI bulk add**: "Add multiple items" opens a dialog where users can type free-form text (e.g., "3 apples, milk expires tomorrow") which Claude Haiku parses into structured data for confirmation
- **Photo identification**: "Snap a photo" lets users photograph their fridge/counter; Claude vision identifies perishable items from the image
- **Clear all**: One-click removal of all items with confirmation dialog, for fridge cleanout scenarios
- **Dev script fix**: Fixed Prisma `--skip-generate` flag removal and added default `DATABASE_URL`/`DIRECT_URL` for local dev

## Test plan

- [ ] Add a single item via the simplified name-only input
- [ ] Expand "Add details" and add an item with quantity, unit, and expiration
- [ ] Tap an existing item to expand inline editor, change fields, and save
- [ ] Use "Add multiple items" with free-form text and verify parsed results
- [ ] Use "Snap a photo" with a food photo and verify identified items
- [ ] Verify duplicate detection in both bulk add and photo flows
- [ ] Test "Clear all" button and confirm dialog
- [ ] Run `npm run dev:full` from a clean checkout (no `.env` file) to verify dev script defaults