### PR TITLE
Add text and photo recipe parsing

### DIFF
--- a/app/api/recipes/parse/route.ts
+++ b/app/api/recipes/parse/route.ts
@@ -1,0 +1,346 @@
+import { NextResponse } from 'next/server'
+import Anthropic from '@anthropic-ai/sdk'
+import { auth } from '@/lib/auth'
+import type { ParsedRecipe, ParsedIngredient } from '@/lib/recipe-parser'
+
+const MODEL = 'claude-haiku-4-5-20251001'
+
+const TEXT_SYSTEM_PROMPT = `You are a recipe parser that extracts structured data from free-form text (cookbook scans, handwritten notes, OCR output).
+
+Extract the following fields:
+- title: Recipe name (required)
+- description: Brief description (optional)
+- prepTimeMinutes: Preparation time in minutes (optional)
+- cookTimeMinutes: Cooking time in minutes (optional)
+- servings: Number of servings (optional)
+- instructions: Step-by-step instructions as a numbered list
+- ingredients: Array of ingredients with:
+  - quantity: Decimal number (e.g., 1.5 for "1 1/2", 0.25 for "1/4")
+  - unit: Standardized unit (cup, tablespoon, teaspoon, ounce, pound, gram, etc.) or null
+  - name: Ingredient name
+  - notes: Additional notes like "chopped", "melted" (optional)
+- tags: Array of tags inferred from the recipe (e.g., "vegetarian", "quick", "baking", cuisine type)
+
+Handle natural language gracefully:
+- Convert fractions to decimals: "1/2" → 0.5, "1 1/4" → 1.25
+- Normalize units: "tbsp" → "tablespoon", "c." → "cup"
+- Extract notes from parentheses or descriptive text
+- Infer tags from ingredients and cooking methods
+
+Respond ONLY with a JSON object. No other text.
+Example output:
+{
+  "title": "Chocolate Chip Cookies",
+  "description": "Classic homemade cookies",
+  "prepTimeMinutes": 15,
+  "cookTimeMinutes": 12,
+  "servings": 24,
+  "instructions": "1. Preheat oven to 375°F\\n2. Mix dry ingredients...",
+  "ingredients": [
+    { "quantity": 2.25, "unit": "cup", "name": "flour", "notes": "all-purpose" },
+    { "quantity": 1, "unit": "teaspoon", "name": "baking soda", "notes": null }
+  ],
+  "tags": ["baking", "dessert", "cookies"]
+}`
+
+const IMAGE_SYSTEM_PROMPT = `You are a recipe parser that extracts structured data from photos of recipes (printed recipes, handwritten recipe cards, cookbook pages).
+
+Look at the image and extract:
+- title: Recipe name (required)
+- description: Brief description (optional)
+- prepTimeMinutes: Preparation time in minutes (optional)
+- cookTimeMinutes: Cooking time in minutes (optional)
+- servings: Number of servings (optional)
+- instructions: Step-by-step instructions as a numbered list
+- ingredients: Array of ingredients with:
+  - quantity: Decimal number (e.g., 1.5 for "1 1/2", 0.25 for "1/4")
+  - unit: Standardized unit (cup, tablespoon, teaspoon, ounce, pound, gram, etc.) or null
+  - name: Ingredient name
+  - notes: Additional notes like "chopped", "melted" (optional)
+- tags: Array of tags inferred from the recipe (e.g., "vegetarian", "quick", "baking", cuisine type)
+
+Handle handwriting and OCR artifacts gracefully:
+- Interpret unclear text based on cooking context
+- Convert fractions to decimals: "1/2" → 0.5, "1 1/4" → 1.25
+- Normalize units: "tbsp" → "tablespoon", "c." → "cup"
+- Extract notes from parentheses or descriptive text
+- Infer tags from ingredients and cooking methods
+
+Respond ONLY with a JSON object. No other text.`
+
+const MAX_IMAGE_SIZE = 5 * 1024 * 1024 // 5MB
+
+export async function POST(request: Request) {
+  try {
+    const session = await auth()
+    if (!session?.user?.householdId) {
+      console.log('[recipe-parse] Unauthorized: no session or householdId')
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    if (!process.env.ANTHROPIC_API_KEY) {
+      console.log('[recipe-parse] ANTHROPIC_API_KEY not configured')
+      return NextResponse.json(
+        { error: 'AI features not configured' },
+        { status: 503 }
+      )
+    }
+
+    const body = await request.json()
+    const { text, image, mediaType } = body
+
+    console.log('[recipe-parse] Request received:', {
+      hasText: !!text,
+      textLength: text?.length,
+      hasImage: !!image,
+      imageLength: image?.length,
+      mediaType,
+    })
+
+    const hasText = text && typeof text === 'string' && text.trim().length > 0
+    const hasImage = image && typeof image === 'string' && mediaType
+
+    if (!hasText && !hasImage) {
+      console.log('[recipe-parse] Validation failed: no text or image')
+      return NextResponse.json(
+        { error: 'Either text or image is required' },
+        { status: 400 }
+      )
+    }
+
+    if (hasText && hasImage) {
+      return NextResponse.json(
+        { error: 'Provide either text or image, not both' },
+        { status: 400 }
+      )
+    }
+
+    // Validate image size (base64 is ~33% larger than binary)
+    if (hasImage) {
+      const estimatedSize = (image.length * 3) / 4
+      console.log('[recipe-parse] Image size check:', {
+        base64Length: image.length,
+        estimatedBytes: estimatedSize,
+        maxBytes: MAX_IMAGE_SIZE,
+      })
+      if (estimatedSize > MAX_IMAGE_SIZE) {
+        return NextResponse.json(
+          { error: 'Image too large. Please use a smaller photo (max 5MB).' },
+          { status: 400 }
+        )
+      }
+    }
+
+    console.log('[recipe-parse] Calling Anthropic API...')
+    const anthropic = new Anthropic()
+
+    let content: Anthropic.MessageCreateParams['messages'][0]['content']
+    let systemPrompt: string
+
+    if (hasImage) {
+      systemPrompt = IMAGE_SYSTEM_PROMPT
+      content = [
+        {
+          type: 'image',
+          source: {
+            type: 'base64',
+            media_type: mediaType as 'image/jpeg' | 'image/png' | 'image/gif' | 'image/webp',
+            data: image,
+          },
+        },
+        {
+          type: 'text',
+          text: 'Extract the recipe from this image.',
+        },
+      ]
+    } else {
+      systemPrompt = TEXT_SYSTEM_PROMPT
+      content = `Parse this recipe text:\n\n${text.trim()}`
+    }
+
+    let response
+    try {
+      response = await anthropic.messages.create({
+        model: MODEL,
+        max_tokens: 2048,
+        system: systemPrompt,
+        messages: [
+          {
+            role: 'user',
+            content,
+          },
+        ],
+      })
+      console.log('[recipe-parse] Anthropic API response received:', {
+        stopReason: response.stop_reason,
+        usage: response.usage,
+      })
+    } catch (apiError) {
+      console.error('[recipe-parse] Anthropic API error:', apiError)
+      throw apiError
+    }
+
+    const textBlock = response.content.find((c) => c.type === 'text')
+    if (!textBlock || textBlock.type !== 'text') {
+      console.error('[recipe-parse] No text in response:', response.content)
+      throw new Error('No text response from AI')
+    }
+
+    console.log('[recipe-parse] AI response text:', textBlock.text.substring(0, 500))
+
+    // Parse the JSON response
+    let parsed: {
+      title: string
+      description?: string | null
+      prepTimeMinutes?: number | null
+      cookTimeMinutes?: number | null
+      servings?: number | null
+      instructions: string | Array<string | { text: string }>
+      ingredients: Array<{
+        quantity?: number | null
+        unit?: string | null
+        name: string
+        notes?: string | null
+      }>
+      tags?: string[]
+    }
+
+    try {
+      // Extract JSON from the response (handle potential markdown code blocks)
+      let jsonText = textBlock.text.trim()
+      if (jsonText.startsWith('```')) {
+        jsonText = jsonText.replace(/^```(?:json)?\n?/, '').replace(/\n?```$/, '')
+      }
+      console.log('[recipe-parse] Parsing JSON, length:', jsonText.length)
+      parsed = JSON.parse(jsonText)
+      console.log('[recipe-parse] JSON parsed successfully, title:', parsed.title)
+    } catch (parseError) {
+      console.error('[recipe-parse] Failed to parse AI response:', textBlock.text)
+      console.error('[recipe-parse] Parse error:', parseError)
+      return NextResponse.json(
+        { error: 'Failed to parse recipe. Please try again.' },
+        { status: 422 }
+      )
+    }
+
+    // Validate required fields
+    console.log('[recipe-parse] Validating parsed data:', {
+      hasTitle: !!parsed.title,
+      titleType: typeof parsed.title,
+      hasInstructions: !!parsed.instructions,
+      instructionsType: typeof parsed.instructions,
+      isInstructionsArray: Array.isArray(parsed.instructions),
+      ingredientCount: parsed.ingredients?.length,
+    })
+
+    if (!parsed.title || typeof parsed.title !== 'string') {
+      console.error('[recipe-parse] Missing title')
+      return NextResponse.json(
+        { error: 'Could not identify recipe title' },
+        { status: 422 }
+      )
+    }
+
+    // Handle instructions as string or array
+    let instructionsText: string
+    if (typeof parsed.instructions === 'string') {
+      instructionsText = parsed.instructions
+    } else if (Array.isArray(parsed.instructions)) {
+      // Convert array of steps to numbered string
+      instructionsText = parsed.instructions
+        .map((step, index) => {
+          if (typeof step === 'string') {
+            return `${index + 1}. ${step}`
+          } else if (step && typeof step === 'object' && 'text' in step) {
+            return `${index + 1}. ${(step as { text: string }).text}`
+          }
+          return null
+        })
+        .filter(Boolean)
+        .join('\n')
+      console.log('[recipe-parse] Converted array instructions to string, length:', instructionsText.length)
+    } else {
+      console.error('[recipe-parse] Missing or invalid instructions')
+      return NextResponse.json(
+        { error: 'Could not extract recipe instructions' },
+        { status: 422 }
+      )
+    }
+
+    if (!instructionsText.trim()) {
+      console.error('[recipe-parse] Empty instructions')
+      return NextResponse.json(
+        { error: 'Could not extract recipe instructions' },
+        { status: 422 }
+      )
+    }
+
+    // Build the recipe object in ParsedRecipe format
+    const ingredients: ParsedIngredient[] = (parsed.ingredients || [])
+      .filter((ing) => ing && typeof ing.name === 'string' && ing.name.trim())
+      .map((ing) => ({
+        quantity: typeof ing.quantity === 'number' ? ing.quantity : null,
+        unit: typeof ing.unit === 'string' ? ing.unit : null,
+        name: ing.name.trim(),
+        notes: typeof ing.notes === 'string' ? ing.notes : null,
+      }))
+
+    const recipe: ParsedRecipe = {
+      title: parsed.title.trim(),
+      description: typeof parsed.description === 'string' ? parsed.description : null,
+      prepTimeMinutes: typeof parsed.prepTimeMinutes === 'number' ? parsed.prepTimeMinutes : null,
+      cookTimeMinutes: typeof parsed.cookTimeMinutes === 'number' ? parsed.cookTimeMinutes : null,
+      servings: typeof parsed.servings === 'number' ? parsed.servings : null,
+      instructions: instructionsText,
+      imageUrl: null,
+      sourceUrl: '',
+      tags: Array.isArray(parsed.tags)
+        ? parsed.tags.filter((t): t is string => typeof t === 'string').slice(0, 10)
+        : [],
+      ingredients,
+    }
+
+    console.log('[recipe-parse] Success! Returning recipe:', recipe.title)
+    return NextResponse.json({
+      recipe,
+      usage: {
+        inputTokens: response.usage.input_tokens,
+        outputTokens: response.usage.output_tokens,
+      },
+    })
+  } catch (error) {
+    console.error('[recipe-parse] Error:', error)
+
+    if (error instanceof Anthropic.APIError) {
+      console.error('[recipe-parse] Anthropic API Error details:', {
+        status: error.status,
+        message: error.message,
+        name: error.name,
+      })
+      if (error.status === 401) {
+        return NextResponse.json(
+          { error: 'Invalid API key configuration' },
+          { status: 503 }
+        )
+      }
+      if (error.status === 429) {
+        return NextResponse.json(
+          { error: 'Rate limit exceeded. Please try again.' },
+          { status: 429 }
+        )
+      }
+      // Return the actual API error message for debugging
+      return NextResponse.json(
+        { error: `API Error: ${error.message}` },
+        { status: error.status || 500 }
+      )
+    }
+
+    // For other errors, include more details
+    const errorMessage = error instanceof Error ? error.message : 'Unknown error'
+    return NextResponse.json(
+      { error: `Failed to parse recipe: ${errorMessage}` },
+      { status: 500 }
+    )
+  }
+}

--- a/components/recipe-form.tsx
+++ b/components/recipe-form.tsx
@@ -15,7 +15,9 @@ import {
   SelectValue,
 } from '@/components/ui/select'
 import { toast } from 'sonner'
-import { Link2, Loader2, ExternalLink } from 'lucide-react'
+import { ExternalLink } from 'lucide-react'
+import { RecipeImportTabs } from '@/components/recipe-import-tabs'
+import type { ParsedRecipe } from '@/lib/recipe-parser'
 
 interface Ingredient {
   id?: string
@@ -62,8 +64,6 @@ export function RecipeForm({ recipe, defaultType = 'MAIN' }: RecipeFormProps) {
   )
   const [imageUrl, setImageUrl] = useState(recipe?.imageUrl || '')
   const [sourceUrl, setSourceUrl] = useState(recipe?.sourceUrl || '')
-  const [importUrl, setImportUrl] = useState('')
-  const [isImporting, setIsImporting] = useState(false)
   const [isSubmitting, setIsSubmitting] = useState(false)
 
   const addIngredient = () => {
@@ -82,52 +82,28 @@ export function RecipeForm({ recipe, defaultType = 'MAIN' }: RecipeFormProps) {
     )
   }
 
-  const handleImport = async () => {
-    if (!importUrl.trim()) return
+  const handleParsedRecipe = (data: ParsedRecipe) => {
+    // Populate form fields with parsed data
+    setTitle(data.title || '')
+    setDescription(data.description || '')
+    setPrepTime(data.prepTimeMinutes?.toString() || '')
+    setCookTime(data.cookTimeMinutes?.toString() || '')
+    setServings(data.servings?.toString() || '4')
+    setInstructions(data.instructions || '')
+    setTags(data.tags?.join(', ') || '')
+    setImageUrl(data.imageUrl || '')
+    setSourceUrl(data.sourceUrl || '')
 
-    setIsImporting(true)
-    try {
-      const response = await fetch('/api/recipes/import', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ url: importUrl }),
-      })
-
-      const data = await response.json()
-
-      if (!response.ok) {
-        throw new Error(data.error || 'Failed to import recipe')
-      }
-
-      // Populate form fields with imported data
-      setTitle(data.title || '')
-      setDescription(data.description || '')
-      setPrepTime(data.prepTimeMinutes?.toString() || '')
-      setCookTime(data.cookTimeMinutes?.toString() || '')
-      setServings(data.servings?.toString() || '4')
-      setInstructions(data.instructions || '')
-      setTags(data.tags?.join(', ') || '')
-      setImageUrl(data.imageUrl || '')
-      setSourceUrl(data.sourceUrl || '')
-
-      // Map imported ingredients to our format
-      if (data.ingredients && data.ingredients.length > 0) {
-        setIngredients(
-          data.ingredients.map((ing: { name: string; quantity?: number | null; unit?: string | null; notes?: string | null }) => ({
-            name: ing.name,
-            quantity: ing.quantity ?? null,
-            unit: ing.unit || '',
-            notes: ing.notes || '',
-          }))
-        )
-      }
-
-      setImportUrl('')
-      toast.success('Recipe imported! Review the details and save when ready.')
-    } catch (error) {
-      toast.error(error instanceof Error ? error.message : 'Failed to import recipe')
-    } finally {
-      setIsImporting(false)
+    // Map imported ingredients to our format
+    if (data.ingredients && data.ingredients.length > 0) {
+      setIngredients(
+        data.ingredients.map((ing) => ({
+          name: ing.name,
+          quantity: ing.quantity ?? null,
+          unit: ing.unit || '',
+          notes: ing.notes || '',
+        }))
+      )
     }
   }
 
@@ -188,51 +164,8 @@ export function RecipeForm({ recipe, defaultType = 'MAIN' }: RecipeFormProps) {
 
   return (
     <form onSubmit={handleSubmit} className="space-y-6">
-      {/* Import from URL section - only show when creating new recipe */}
-      {!isEditing && (
-        <Card>
-          <CardHeader>
-            <CardTitle className="flex items-center gap-2">
-              <Link2 className="h-5 w-5" />
-              Import from URL
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="flex gap-2">
-              <Input
-                value={importUrl}
-                onChange={(e) => setImportUrl(e.target.value)}
-                placeholder="https://www.allrecipes.com/recipe/..."
-                disabled={isImporting}
-                onKeyDown={(e) => {
-                  if (e.key === 'Enter') {
-                    e.preventDefault()
-                    handleImport()
-                  }
-                }}
-              />
-              <Button
-                type="button"
-                variant="secondary"
-                onClick={handleImport}
-                disabled={isImporting || !importUrl.trim()}
-              >
-                {isImporting ? (
-                  <>
-                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                    Importing...
-                  </>
-                ) : (
-                  'Import'
-                )}
-              </Button>
-            </div>
-            <p className="text-sm text-muted-foreground mt-2">
-              Paste a recipe URL to auto-fill the form. Works with most recipe websites.
-            </p>
-          </CardContent>
-        </Card>
-      )}
+      {/* Import section - only show when creating new recipe */}
+      {!isEditing && <RecipeImportTabs onParsed={handleParsedRecipe} />}
 
       {/* Imported recipe info (source URL and image preview) */}
       {(sourceUrl || imageUrl) && (

--- a/components/recipe-import-tabs.tsx
+++ b/components/recipe-import-tabs.tsx
@@ -1,0 +1,362 @@
+'use client'
+
+import { useState, useRef } from 'react'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Textarea } from '@/components/ui/textarea'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import { toast } from 'sonner'
+import { Link2, Loader2, FileText, Camera, Upload } from 'lucide-react'
+import type { ParsedRecipe } from '@/lib/recipe-parser'
+
+interface RecipeImportTabsProps {
+  onParsed: (recipe: ParsedRecipe) => void
+}
+
+export function RecipeImportTabs({ onParsed }: RecipeImportTabsProps) {
+  const [activeTab, setActiveTab] = useState('url')
+
+  // URL import state
+  const [importUrl, setImportUrl] = useState('')
+  const [isImportingUrl, setIsImportingUrl] = useState(false)
+
+  // Text parse state
+  const [recipeText, setRecipeText] = useState('')
+  const [isParsingText, setIsParsingText] = useState(false)
+
+  // Photo parse state
+  const [isParsingPhoto, setIsParsingPhoto] = useState(false)
+  const [photoPreview, setPhotoPreview] = useState<string | null>(null)
+  const [photoError, setPhotoError] = useState<string | null>(null)
+  const fileInputRef = useRef<HTMLInputElement>(null)
+
+  const handleImportUrl = async () => {
+    if (!importUrl.trim()) return
+
+    setIsImportingUrl(true)
+    try {
+      const response = await fetch('/api/recipes/import', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ url: importUrl }),
+      })
+
+      const data = await response.json()
+
+      if (!response.ok) {
+        throw new Error(data.error || 'Failed to import recipe')
+      }
+
+      onParsed(data)
+      setImportUrl('')
+      toast.success('Recipe imported! Review the details and save when ready.')
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Failed to import recipe')
+    } finally {
+      setIsImportingUrl(false)
+    }
+  }
+
+  const handleParseText = async () => {
+    if (!recipeText.trim()) return
+
+    setIsParsingText(true)
+    try {
+      const response = await fetch('/api/recipes/parse', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ text: recipeText }),
+      })
+
+      const data = await response.json()
+
+      if (!response.ok) {
+        throw new Error(data.error || 'Failed to parse recipe')
+      }
+
+      onParsed(data.recipe)
+      setRecipeText('')
+      toast.success('Recipe parsed! Review the details and save when ready.')
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Failed to parse recipe')
+    } finally {
+      setIsParsingText(false)
+    }
+  }
+
+  const handlePhotoSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0]
+    if (!file) return
+
+    // Reset the input so the same file can be re-selected
+    e.target.value = ''
+
+    processFile(file)
+  }
+
+  const processFile = async (file: File) => {
+    // Clear any previous error
+    setPhotoError(null)
+
+    if (!file.type.startsWith('image/')) {
+      toast.error('Please select an image file')
+      return
+    }
+
+    if (file.size > 5 * 1024 * 1024) {
+      toast.error('Image too large. Please use a smaller photo (max 5MB).')
+      return
+    }
+
+    // Read as base64
+    const reader = new FileReader()
+    reader.onerror = () => {
+      console.error('[recipe-import] FileReader error:', reader.error)
+      toast.error('Failed to read image file')
+      setPhotoError('Failed to read image file')
+    }
+    reader.onload = async () => {
+      const dataUrl = reader.result as string
+      const base64 = dataUrl.split(',')[1]
+      const mediaType = dataUrl.split(';')[0].split(':')[1]
+
+      console.log('[recipe-import] Image loaded:', {
+        mediaType,
+        base64Length: base64?.length,
+      })
+
+      setPhotoPreview(dataUrl)
+      setIsParsingPhoto(true)
+
+      try {
+        console.log('[recipe-import] Sending to API...')
+        const response = await fetch('/api/recipes/parse', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ image: base64, mediaType }),
+        })
+
+        console.log('[recipe-import] API response status:', response.status)
+        const data = await response.json()
+        console.log('[recipe-import] API response data:', data)
+
+        if (!response.ok) {
+          throw new Error(data.error || 'Failed to parse recipe')
+        }
+
+        onParsed(data.recipe)
+        setPhotoPreview(null)
+        setPhotoError(null)
+        toast.success('Recipe parsed! Review the details and save when ready.')
+      } catch (error) {
+        console.error('[recipe-import] Error:', error)
+        const errorMessage = error instanceof Error ? error.message : 'Failed to parse recipe'
+        setPhotoError(errorMessage)
+        toast.error(errorMessage)
+      } finally {
+        setIsParsingPhoto(false)
+      }
+    }
+    reader.readAsDataURL(file)
+  }
+
+  const handleDrop = (e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault()
+    e.stopPropagation()
+
+    const file = e.dataTransfer.files?.[0]
+    if (!file) return
+
+    processFile(file)
+  }
+
+  const handleDragOver = (e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault()
+    e.stopPropagation()
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Import Recipe</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <Tabs value={activeTab} onValueChange={setActiveTab}>
+          <TabsList className="grid w-full grid-cols-3">
+            <TabsTrigger value="url" className="flex items-center gap-2">
+              <Link2 className="h-4 w-4" />
+              URL
+            </TabsTrigger>
+            <TabsTrigger value="text" className="flex items-center gap-2">
+              <FileText className="h-4 w-4" />
+              Text
+            </TabsTrigger>
+            <TabsTrigger value="photo" className="flex items-center gap-2">
+              <Camera className="h-4 w-4" />
+              Photo
+            </TabsTrigger>
+          </TabsList>
+
+          <TabsContent value="url" className="space-y-3 mt-4">
+            <div className="flex gap-2">
+              <Input
+                value={importUrl}
+                onChange={(e) => setImportUrl(e.target.value)}
+                placeholder="https://www.allrecipes.com/recipe/..."
+                disabled={isImportingUrl}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') {
+                    e.preventDefault()
+                    handleImportUrl()
+                  }
+                }}
+              />
+              <Button
+                type="button"
+                variant="secondary"
+                onClick={handleImportUrl}
+                disabled={isImportingUrl || !importUrl.trim()}
+              >
+                {isImportingUrl ? (
+                  <>
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                    Importing...
+                  </>
+                ) : (
+                  'Import'
+                )}
+              </Button>
+            </div>
+            <p className="text-sm text-muted-foreground">
+              Paste a recipe URL to auto-fill the form. Works with most recipe websites.
+            </p>
+          </TabsContent>
+
+          <TabsContent value="text" className="space-y-3 mt-4">
+            <Textarea
+              value={recipeText}
+              onChange={(e) => setRecipeText(e.target.value)}
+              placeholder={`Paste or type a recipe here. For example:
+
+Grandma's Chocolate Chip Cookies
+
+Prep: 15 min, Cook: 12 min, Makes 24 cookies
+
+Ingredients:
+2 1/4 cups flour
+1 tsp baking soda
+1 cup butter, softened
+3/4 cup sugar
+2 eggs
+1 tsp vanilla
+2 cups chocolate chips
+
+Instructions:
+1. Preheat oven to 375°F
+2. Mix flour and baking soda
+3. Cream butter and sugar
+...`}
+              className="min-h-[200px]"
+              disabled={isParsingText}
+            />
+            <div className="flex justify-end">
+              <Button
+                type="button"
+                variant="secondary"
+                onClick={handleParseText}
+                disabled={isParsingText || !recipeText.trim()}
+              >
+                {isParsingText ? (
+                  <>
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                    Parsing...
+                  </>
+                ) : (
+                  'Parse Recipe'
+                )}
+              </Button>
+            </div>
+            <p className="text-sm text-muted-foreground">
+              Paste text from cookbooks, handwritten notes, or OCR output. AI will extract the recipe details.
+            </p>
+          </TabsContent>
+
+          <TabsContent value="photo" className="space-y-3 mt-4">
+            {isParsingPhoto && photoPreview ? (
+              <div className="flex flex-col items-center gap-4 py-6">
+                <img
+                  src={photoPreview}
+                  alt="Recipe being processed"
+                  className="max-h-[200px] rounded-lg object-cover"
+                />
+                <div className="flex items-center gap-2 text-muted-foreground">
+                  <Loader2 className="h-5 w-5 animate-spin" />
+                  Extracting recipe from image...
+                </div>
+              </div>
+            ) : photoError && photoPreview ? (
+              <div className="flex flex-col items-center gap-4 py-6">
+                <img
+                  src={photoPreview}
+                  alt="Failed to process"
+                  className="max-h-[200px] rounded-lg object-cover opacity-75"
+                />
+                <div className="text-center">
+                  <p className="text-sm text-destructive mb-2">{photoError}</p>
+                  <div className="flex gap-2 justify-center">
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      onClick={() => {
+                        setPhotoPreview(null)
+                        setPhotoError(null)
+                      }}
+                    >
+                      Clear
+                    </Button>
+                    <Button
+                      type="button"
+                      variant="secondary"
+                      size="sm"
+                      onClick={() => fileInputRef.current?.click()}
+                    >
+                      Try Another
+                    </Button>
+                  </div>
+                </div>
+              </div>
+            ) : (
+              <div
+                onDrop={handleDrop}
+                onDragOver={handleDragOver}
+                className="border-2 border-dashed border-muted-foreground/25 rounded-lg p-8 text-center hover:border-muted-foreground/50 transition-colors cursor-pointer"
+                onClick={() => fileInputRef.current?.click()}
+              >
+                <Upload className="h-10 w-10 mx-auto mb-4 text-muted-foreground/50" />
+                <p className="text-sm font-medium mb-1">
+                  Drop a recipe image here, or click to select
+                </p>
+                <p className="text-xs text-muted-foreground">
+                  Supports printed recipes, handwritten recipe cards, cookbook pages
+                </p>
+              </div>
+            )}
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept="image/*"
+              capture="environment"
+              onChange={handlePhotoSelect}
+              className="hidden"
+            />
+            <p className="text-sm text-muted-foreground">
+              Take a photo or upload an image of a recipe. AI will extract the text and details.
+            </p>
+          </TabsContent>
+        </Tabs>
+      </CardContent>
+    </Card>
+  )
+}

--- a/components/ui/tabs.tsx
+++ b/components/ui/tabs.tsx
@@ -1,0 +1,55 @@
+"use client"
+
+import * as React from "react"
+import * as TabsPrimitive from "@radix-ui/react-tabs"
+
+import { cn } from "@/lib/utils"
+
+const Tabs = TabsPrimitive.Root
+
+const TabsList = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.List>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.List>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.List
+    ref={ref}
+    className={cn(
+      "inline-flex h-9 items-center justify-center rounded-lg bg-muted p-1 text-muted-foreground",
+      className
+    )}
+    {...props}
+  />
+))
+TabsList.displayName = TabsPrimitive.List.displayName
+
+const TabsTrigger = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.Trigger
+    ref={ref}
+    className={cn(
+      "inline-flex items-center justify-center whitespace-nowrap rounded-md px-3 py-1 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow",
+      className
+    )}
+    {...props}
+  />
+))
+TabsTrigger.displayName = TabsPrimitive.Trigger.displayName
+
+const TabsContent = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Content>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.Content
+    ref={ref}
+    className={cn(
+      "mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+      className
+    )}
+    {...props}
+  />
+))
+TabsContent.displayName = TabsPrimitive.Content.displayName
+
+export { Tabs, TabsList, TabsTrigger, TabsContent }

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@radix-ui/react-separator": "^1.1.8",
         "@radix-ui/react-slot": "^1.2.4",
         "@radix-ui/react-switch": "^1.2.6",
+        "@radix-ui/react-tabs": "^1.1.13",
         "bcryptjs": "^3.0.3",
         "cheerio": "^1.1.2",
         "class-variance-authority": "^0.7.1",
@@ -2764,6 +2765,92 @@
       }
     },
     "node_modules/@radix-ui/react-switch/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tabs": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tabs/-/react-tabs-1.1.13.tgz",
+      "integrity": "sha512-7xdcatg7/U+7+Udyoj2zodtI9H/IIopqo+YOIcZOq1nJwXWBZ9p8xiu5llXlekDbZkca79a/fozEYQXIA4sW6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-roving-focus": "1.1.11",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tabs/node_modules/@radix-ui/react-context": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
+      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tabs/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tabs/node_modules/@radix-ui/react-slot": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
       "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@radix-ui/react-separator": "^1.1.8",
     "@radix-ui/react-slot": "^1.2.4",
     "@radix-ui/react-switch": "^1.2.6",
+    "@radix-ui/react-tabs": "^1.1.13",
     "bcryptjs": "^3.0.3",
     "cheerio": "^1.1.2",
     "class-variance-authority": "^0.7.1",


### PR DESCRIPTION
## Summary

- Add ability to parse recipes from free-form text (cookbook scans, handwritten notes, OCR output)
- Add ability to parse recipes from photos using Claude vision (printed recipes, handwritten recipe cards, cookbook pages)
- Replace single URL import card with tabbed interface (URL / Text / Photo)

## Changes

**New files:**
- `app/api/recipes/parse/route.ts` - API endpoint using `claude-haiku-4-5` for text and image parsing
- `components/recipe-import-tabs.tsx` - Tabbed import UI with drag-drop support for photos
- `components/ui/tabs.tsx` - Radix UI tabs component

**Modified:**
- `components/recipe-form.tsx` - Use new `RecipeImportTabs` component

## Features

- Text parsing handles natural language, fractions, unit normalization
- Photo parsing uses Claude vision to extract recipe from images
- Drag-and-drop or file picker for photo upload
- Camera capture on mobile devices
- Error states with retry option
- Infers recipe tags from content

## Test plan

- [ ] Navigate to /recipes/new
- [ ] Test URL import (existing functionality)
- [ ] Test text parsing with pasted recipe text
- [ ] Test photo upload with recipe image
- [ ] Verify form population after each import method
- [ ] Save parsed recipe and verify data